### PR TITLE
Enhance Bedwars plugin with upgrade NPCs and tier upgrade mechanics

### DIFF
--- a/example_arena.yml
+++ b/example_arena.yml
@@ -66,6 +66,13 @@ teams:
       z: 0.5
       yaw: 90.0
       pitch: 0.0
+    upgrade-npc:
+      world: bedwars_world
+      x: 27.5
+      y: 65.0
+      z: 0.5
+      yaw: 90.0
+      pitch: 0.0
 
   BLUE:
     color: BLUE
@@ -102,6 +109,13 @@ teams:
     shop-npc:
       world: bedwars_world
       x: -28.5
+      y: 65.0
+      z: 0.5
+      yaw: -90.0
+      pitch: 0.0
+    upgrade-npc:
+      world: bedwars_world
+      x: -27.5
       y: 65.0
       z: 0.5
       yaw: -90.0

--- a/src/main/java/com/kartersanamo/bedwars/Bedwars.java
+++ b/src/main/java/com/kartersanamo/bedwars/Bedwars.java
@@ -27,6 +27,7 @@ public final class Bedwars extends JavaPlugin implements IBedwars {
     private ArenaManager arenaManager;
     private InternalAdapter internalAdapter;
     private com.kartersanamo.bedwars.shop.ShopManager shopManager;
+    private com.kartersanamo.bedwars.upgrades.UpgradeManager upgradeManager;
     private com.kartersanamo.bedwars.sidebar.SidebarService sidebarService;
     private com.kartersanamo.bedwars.hologram.HologramManager hologramManager;
 
@@ -43,7 +44,8 @@ public final class Bedwars extends JavaPlugin implements IBedwars {
 
         this.internalAdapter = new InternalAdapter();
         this.shopManager = new com.kartersanamo.bedwars.shop.ShopManager();
-        this.sidebarService = new com.kartersanamo.bedwars.sidebar.SidebarService();
+        this.upgradeManager = new com.kartersanamo.bedwars.upgrades.UpgradeManager();
+        this.sidebarService = new com.kartersanamo.bedwars.sidebar.SidebarService(this);
         this.hologramManager = new com.kartersanamo.bedwars.hologram.HologramManager(this);
 
         initialiseDatabase();
@@ -55,11 +57,13 @@ public final class Bedwars extends JavaPlugin implements IBedwars {
         getServer().getPluginManager().registerEvents(new com.kartersanamo.bedwars.listeners.DeathListener(this), this);
         getServer().getPluginManager().registerEvents(new com.kartersanamo.bedwars.listeners.DamageListener(this), this);
         getServer().getPluginManager().registerEvents(new com.kartersanamo.bedwars.listeners.ChatListener(this), this);
-        getServer().getPluginManager().registerEvents(new com.kartersanamo.bedwars.shop.listeners.ShopOpenListener(shopManager), this);
+        getServer().getPluginManager().registerEvents(new com.kartersanamo.bedwars.shop.listeners.ShopOpenListener(this, shopManager, upgradeManager), this);
         getServer().getPluginManager().registerEvents(new com.kartersanamo.bedwars.shop.listeners.ShopInventoryListener(this, shopManager), this);
+        getServer().getPluginManager().registerEvents(new com.kartersanamo.bedwars.upgrades.UpgradesInventoryListener(upgradeManager), this);
         getServer().getPluginManager().registerEvents(new com.kartersanamo.bedwars.sidebar.SidebarListener(sidebarService), this);
         getServer().getPluginManager().registerEvents(new com.kartersanamo.bedwars.gui.GameModeGuiListener(this), this);
         getServer().getPluginManager().registerEvents(new com.kartersanamo.bedwars.listeners.SwordAndArmorEnforcementListener(this), this);
+        getServer().getPluginManager().registerEvents(new com.kartersanamo.bedwars.listeners.HungerListener(this), this);
 
         final com.kartersanamo.bedwars.commands.bedwars.BedwarsCommand bedwarsCommand =
                 new com.kartersanamo.bedwars.commands.bedwars.BedwarsCommand();
@@ -75,6 +79,10 @@ public final class Bedwars extends JavaPlugin implements IBedwars {
         // Start sidebar refresh task (once per second).
         new com.kartersanamo.bedwars.sidebar.SidebarUpdateTask(this, sidebarService)
                 .runTaskTimer(this, 20L, 20L);
+
+        // Apply Haste and Heal Pool every 2 seconds.
+        new com.kartersanamo.bedwars.arena.tasks.UpgradesApplyTask(this, arenaManager)
+                .runTaskTimer(this, 40L, 40L);
 
     }
 

--- a/src/main/java/com/kartersanamo/bedwars/api/arena/IArena.java
+++ b/src/main/java/com/kartersanamo/bedwars/api/arena/IArena.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * High-level arena contract used by the rest of the plugin.
@@ -76,6 +77,11 @@ public interface IArena {
     void handlePlayerDeath(Player player, Player killer);
 
     /**
+     * Records a kill for the given killer (for end-of-game summary). Call when a player gets a kill.
+     */
+    void recordKill(UUID killerUniqueId);
+
+    /**
      * Returns whether the player currently has spawn protection (invulnerability after respawn).
      */
     boolean hasSpawnProtection(Player player);
@@ -89,4 +95,27 @@ public interface IArena {
      * Resets the arena back to the lobby state after a game finishes.
      */
     void resetAfterGame();
+
+    /**
+     * Broadcasts the game-over summary (Bed Wars title, winner, top killers) to all players and spectators.
+     * Call when the game transitions to ENDING.
+     *
+     * @param winningTeam the last remaining team, or null if draw
+     */
+    void broadcastGameOverSummary(ITeam winningTeam);
+
+    /** Current diamond generator tier (1, 2, or 3). */
+    int getDiamondTier();
+
+    /** Current emerald generator tier (1, 2, or 3). */
+    int getEmeraldTier();
+
+    /** Effective spawn interval in ticks for diamond generators at current tier. */
+    int getEffectiveDiamondIntervalTicks();
+
+    /** Effective spawn interval in ticks for emerald generators at current tier. */
+    int getEffectiveEmeraldIntervalTicks();
+
+    /** Next tier upgrade line for scoreboard (e.g. "Diamond II in 5:36"); updates every second. */
+    String getNextTierUpgradeMessage();
 }

--- a/src/main/java/com/kartersanamo/bedwars/api/configuration/ConfigPath.java
+++ b/src/main/java/com/kartersanamo/bedwars/api/configuration/ConfigPath.java
@@ -72,6 +72,20 @@ public final class ConfigPath {
         public static final String EMERALD_INTERVAL_TICKS = "emerald.interval-ticks";
         public static final String EMERALD_MAX_ITEMS = "emerald.max-items";
 
+        /** Tier upgrade event times (seconds from game start). Order: Diamond II, Emerald II, Diamond III, Emerald III, Bed Break, Sudden Death. */
+        public static final String TIER_UPGRADE_DIAMOND_2 = "tier-upgrades.diamond-2-seconds";
+        public static final String TIER_UPGRADE_EMERALD_2 = "tier-upgrades.emerald-2-seconds";
+        public static final String TIER_UPGRADE_DIAMOND_3 = "tier-upgrades.diamond-3-seconds";
+        public static final String TIER_UPGRADE_EMERALD_3 = "tier-upgrades.emerald-3-seconds";
+        public static final String TIER_UPGRADE_BED_BREAK = "tier-upgrades.bed-break-seconds";
+        public static final String TIER_UPGRADE_SUDDEN_DEATH = "tier-upgrades.sudden-death-seconds";
+
+        /** Interval ticks per tier (diamond/emerald). Tier 2/3 use these; tier 1 uses base interval. */
+        public static final String DIAMOND_TIER_2_INTERVAL_TICKS = "diamond.tier-2-interval-ticks";
+        public static final String DIAMOND_TIER_3_INTERVAL_TICKS = "diamond.tier-3-interval-ticks";
+        public static final String EMERALD_TIER_2_INTERVAL_TICKS = "emerald.tier-2-interval-ticks";
+        public static final String EMERALD_TIER_3_INTERVAL_TICKS = "emerald.tier-3-interval-ticks";
+
         private Generators() {
         }
     }
@@ -115,6 +129,7 @@ public final class ConfigPath {
         public static final String TEAM_IRON_GENERATORS = "generator-iron";
         public static final String TEAM_GOLD_GENERATORS = "generator-gold";
         public static final String TEAM_SHOP_NPC = "shop-npc";
+        public static final String TEAM_UPGRADE_NPC = "upgrade-npc";
 
         public static final String DIAMOND_GENERATORS = "diamond-generators";
         public static final String EMERALD_GENERATORS = "emerald-generators";

--- a/src/main/java/com/kartersanamo/bedwars/arena/Arena.java
+++ b/src/main/java/com/kartersanamo/bedwars/arena/Arena.java
@@ -12,15 +12,24 @@ import com.kartersanamo.bedwars.arena.tasks.GamePlayingTask;
 import com.kartersanamo.bedwars.arena.tasks.GameRestartingTask;
 import com.kartersanamo.bedwars.arena.tasks.GameStartingTask;
 import com.kartersanamo.bedwars.sidebar.SidebarService;
+import com.kartersanamo.bedwars.upgrades.TeamUpgradeState;
+import com.kartersanamo.bedwars.upgrades.TrapType;
+import com.kartersanamo.bedwars.Bedwars;
 import com.kartersanamo.bedwars.configuration.ArenaConfig;
+import com.kartersanamo.bedwars.configuration.GeneratorsConfig;
 import com.kartersanamo.bedwars.configuration.MainConfig;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.Sound;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -62,6 +71,18 @@ public final class Arena implements IArena {
     private final Map<UUID, ToolTier> playerPickaxeTier = new HashMap<>();
     private final Set<UUID> playerHasShears = new HashSet<>();
 
+    /** Kill count this game per player (for end-of-game summary). */
+    private final Map<UUID, Integer> killCountThisGame = new HashMap<>();
+
+    /** Per-team diamond upgrade and trap state. */
+    private final Map<String, TeamUpgradeState> teamUpgradeStates = new HashMap<>();
+
+    /** Players currently inside an enemy base (teamId -> set of player UUIDs) for trap trigger cooldown. */
+    private final Map<String, Set<UUID>> playersInsideEnemyBase = new HashMap<>();
+
+    private static final int BASE_TRAP_RADIUS = 10;
+    private static final int HEAL_POOL_RADIUS = 12;
+
     private final JavaPlugin plugin;
 
     private boolean enabled = true;
@@ -69,6 +90,12 @@ public final class Arena implements IArena {
 
     private GameStartingTask startingTask;
     private GamePlayingTask playingTask;
+
+    /** When the game started (IN_GAME); used for tier upgrade timers. */
+    private long gameStartMillis;
+    private int diamondTier = 1;
+    private int emeraldTier = 1;
+    private GeneratorPhase generatorPhase = GeneratorPhase.NORMAL;
 
     private Arena(final String id,
                   final String displayName,
@@ -94,6 +121,9 @@ public final class Arena implements IArena {
         this.lobbyRegion = lobbyRegion;
         this.teams = Collections.unmodifiableList(new ArrayList<>(teams));
         this.plugin = plugin;
+        for (ITeam t : teams) {
+            this.teamUpgradeStates.put(t.getId(), new TeamUpgradeState());
+        }
     }
 
     public static Arena fromConfig(final ArenaConfig config,
@@ -253,6 +283,10 @@ public final class Arena implements IArena {
         return teams;
     }
 
+    public TeamUpgradeState getTeamUpgradeState(final ITeam team) {
+        return team == null ? null : teamUpgradeStates.get(team.getId());
+    }
+
     @Override
     public Optional<ITeam> getTeam(final Player player) {
         return teams.stream()
@@ -397,6 +431,10 @@ public final class Arena implements IArena {
             return;
         }
         gameState = EGameState.IN_GAME;
+        gameStartMillis = System.currentTimeMillis();
+        diamondTier = 1;
+        emeraldTier = 1;
+        generatorPhase = GeneratorPhase.NORMAL;
 
         // Assign all players to teams randomly, then teleport (addPlayer teleports to team spawn).
         assignAllPlayersToTeamsRandomly();
@@ -410,6 +448,7 @@ public final class Arena implements IArena {
 
         for (Player p : getPlayers()) {
             giveStarterKit(p);
+            sendGameStartIntro(p);
         }
 
         clearLobbyRegion();
@@ -421,27 +460,82 @@ public final class Arena implements IArena {
         playingTask.runTaskTimer(plugin, 20L, 20L);
     }
 
+    private static void sendGameStartIntro(final Player player) {
+        final String separator = ChatColor.GREEN + "▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬";
+        player.sendMessage(separator);
+        player.sendTitle(
+                ChatColor.WHITE + "Bed Wars",
+                ChatColor.YELLOW + "Protect your bed and destroy the enemy beds.",
+                10, 70, 20
+        );
+        player.sendMessage(ChatColor.YELLOW + "Protect your bed and destroy the enemy beds.");
+        player.sendMessage(ChatColor.YELLOW + "Upgrade yourself and your team by collecting");
+        player.sendMessage(ChatColor.YELLOW + "Iron, Gold, Emerald and Diamond from generators");
+        player.sendMessage(ChatColor.YELLOW + "to access powerful upgrades.");
+        player.sendMessage(separator);
+    }
+
     private static final int RESPAWN_SPECTATOR_SECONDS = 3;
     private static final int SPAWN_PROTECTION_SECONDS = 2;
 
     @Override
     public void handlePlayerDeath(final Player player, final Player killer) {
+        player.teleport(spectatorSpawn);
+        player.setGameMode(GameMode.SPECTATOR);
+
         final Optional<ITeam> teamOpt = getTeam(player);
         final boolean bedDestroyed = teamOpt.map(ITeam::isBedDestroyed).orElse(true);
 
         if (bedDestroyed) {
-            // Eliminated: move to spectators permanently.
+            player.sendMessage(ChatColor.RED + "You have been eliminated!");
+            final Optional<ITeam> eliminatedTeamOpt = teamOpt;
             players.remove(player.getUniqueId());
             spectators.add(player.getUniqueId());
-            player.teleport(spectatorSpawn);
-            player.setGameMode(GameMode.SPECTATOR);
+            if (eliminatedTeamOpt.isPresent()) {
+                final ITeam eliminatedTeam = eliminatedTeamOpt.get();
+                boolean anyLeft = false;
+                for (UUID memberId : eliminatedTeam.getMemberIds()) {
+                    if (players.contains(memberId)) {
+                        anyLeft = true;
+                        break;
+                    }
+                }
+                if (!anyLeft) {
+                    final String colorName = eliminatedTeam.getColor().name().charAt(0) + eliminatedTeam.getColor().name().substring(1).toLowerCase(Locale.ROOT);
+                    final String msg = ChatColor.WHITE.toString() + ChatColor.BOLD + "TEAM ELIMINATED > "
+                            + eliminatedTeam.getColor().getChatColor() + colorName + " Team"
+                            + ChatColor.WHITE + " has been eliminated!";
+                    for (Player p : getPlayers()) {
+                        p.sendMessage(msg);
+                    }
+                    for (Player p : getSpectators()) {
+                        p.sendMessage(msg);
+                    }
+                }
+            }
             return;
         }
 
-        // Respawn flow: spectator for 3 seconds, then respawn at base with 2 seconds spawn protection.
-        player.setGameMode(GameMode.SPECTATOR);
-        // Keep in players; do not add to spectators.
-        Bukkit.getScheduler().runTaskLater(plugin, () -> respawnAtBase(player), RESPAWN_SPECTATOR_SECONDS * 20L);
+        // Respawn flow: title/subtitle + chat countdown, then respawn at base after RESPAWN_SPECTATOR_SECONDS.
+        player.sendTitle(
+                ChatColor.RED + "YOU DIED!",
+                ChatColor.YELLOW + "You will respawn in " + RESPAWN_SPECTATOR_SECONDS + " seconds!",
+                10, 70, 20
+        );
+        player.sendMessage(ChatColor.YELLOW + "You will respawn in " + RESPAWN_SPECTATOR_SECONDS + " seconds!");
+        for (int s = RESPAWN_SPECTATOR_SECONDS - 1; s >= 1; s--) {
+            final int secondsLeft = s;
+            final String msg = s == 1
+                    ? ChatColor.YELLOW + "You will respawn in 1 second!"
+                    : ChatColor.YELLOW + "You will respawn in " + secondsLeft + " seconds!";
+            Bukkit.getScheduler().runTaskLater(plugin, () -> player.sendMessage(msg), (RESPAWN_SPECTATOR_SECONDS - secondsLeft) * 20L);
+        }
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            respawnAtBase(player);
+            if (players.contains(player.getUniqueId())) {
+                player.sendMessage(ChatColor.YELLOW + "You have respawned!");
+            }
+        }, RESPAWN_SPECTATOR_SECONDS * 20L);
     }
 
     /**
@@ -477,6 +571,22 @@ public final class Arena implements IArena {
     @Override
     public void handleBedDestroyed(final ITeam victimTeam, final Player breaker) {
         victimTeam.setBedDestroyed(true);
+        if (plugin instanceof Bedwars bw) {
+            try {
+                bw.getDatabase().getCachedStats(breaker.getUniqueId(), breaker.getName()).incrementBedsBroken();
+            } catch (Exception ignored) {
+            }
+        }
+        final String colorName = victimTeam.getColor().name().charAt(0) + victimTeam.getColor().name().substring(1).toLowerCase(Locale.ROOT);
+        final String message = ChatColor.WHITE.toString() + ChatColor.BOLD + "BED DESTRUCTION > "
+                + victimTeam.getColor().getChatColor() + colorName + " Bed"
+                + ChatColor.WHITE + " was destroyed by " + breaker.getName() + "!";
+        for (Player p : getPlayers()) {
+            p.sendMessage(message);
+        }
+        for (Player p : getSpectators()) {
+            p.sendMessage(message);
+        }
     }
 
     @Override
@@ -490,8 +600,173 @@ public final class Arena implements IArena {
         playerHasShears.clear();
         for (ITeam team : teams) {
             team.resetTeam();
+            final TeamUpgradeState state = teamUpgradeStates.get(team.getId());
+            if (state != null) {
+                state.reset();
+            }
         }
+        playersInsideEnemyBase.clear();
+        killCountThisGame.clear();
+        diamondTier = 1;
+        emeraldTier = 1;
+        generatorPhase = GeneratorPhase.NORMAL;
         gameState = EGameState.LOBBY_WAITING;
+    }
+
+    /** Called every second (or tick) to apply tier upgrades when time is reached. */
+    public void checkTierUpgrades() {
+        if (gameState != EGameState.IN_GAME && gameState != EGameState.ENDING) {
+            return;
+        }
+        final GeneratorsConfig config = plugin instanceof Bedwars ? ((Bedwars) plugin).getGeneratorsConfig() : null;
+        if (config == null) {
+            return;
+        }
+        final long elapsedSeconds = (System.currentTimeMillis() - gameStartMillis) / 1000L;
+
+        if (diamondTier < 2 && elapsedSeconds >= config.getTierUpgradeDiamond2Seconds()) {
+            diamondTier = 2;
+        }
+        if (emeraldTier < 2 && elapsedSeconds >= config.getTierUpgradeEmerald2Seconds()) {
+            emeraldTier = 2;
+        }
+        if (diamondTier < 3 && elapsedSeconds >= config.getTierUpgradeDiamond3Seconds()) {
+            diamondTier = 3;
+        }
+        if (emeraldTier < 3 && elapsedSeconds >= config.getTierUpgradeEmerald3Seconds()) {
+            emeraldTier = 3;
+        }
+        if (generatorPhase == GeneratorPhase.NORMAL && elapsedSeconds >= config.getTierUpgradeBedBreakSeconds()) {
+            generatorPhase = GeneratorPhase.BED_BREAK;
+        }
+        if (generatorPhase != GeneratorPhase.SUDDEN_DEATH && elapsedSeconds >= config.getTierUpgradeSuddenDeathSeconds()) {
+            generatorPhase = GeneratorPhase.SUDDEN_DEATH;
+        }
+    }
+
+    @Override
+    public int getDiamondTier() {
+        return diamondTier;
+    }
+
+    @Override
+    public int getEmeraldTier() {
+        return emeraldTier;
+    }
+
+    @Override
+    public int getEffectiveDiamondIntervalTicks() {
+        final GeneratorsConfig config = plugin instanceof Bedwars ? ((Bedwars) plugin).getGeneratorsConfig() : null;
+        if (config == null) return 600;
+        return switch (diamondTier) {
+            case 2 -> config.getDiamondTier2IntervalTicks();
+            case 3 -> config.getDiamondTier3IntervalTicks();
+            default -> config.getDiamondIntervalTicks();
+        };
+    }
+
+    @Override
+    public int getEffectiveEmeraldIntervalTicks() {
+        final GeneratorsConfig config = plugin instanceof Bedwars ? ((Bedwars) plugin).getGeneratorsConfig() : null;
+        if (config == null) return 1200;
+        return switch (emeraldTier) {
+            case 2 -> config.getEmeraldTier2IntervalTicks();
+            case 3 -> config.getEmeraldTier3IntervalTicks();
+            default -> config.getEmeraldIntervalTicks();
+        };
+    }
+
+    @Override
+    public String getNextTierUpgradeMessage() {
+        final GeneratorsConfig config = plugin instanceof Bedwars ? ((Bedwars) plugin).getGeneratorsConfig() : null;
+        if (config == null) return ChatColor.GRAY + "—";
+        final long elapsedSeconds = (System.currentTimeMillis() - gameStartMillis) / 1000L;
+
+        if (diamondTier < 2) {
+            final int at = config.getTierUpgradeDiamond2Seconds();
+            final long rem = Math.max(0, at - elapsedSeconds);
+            return ChatColor.WHITE + "Diamond II in " + ChatColor.GREEN + formatTime(rem);
+        }
+        if (emeraldTier < 2) {
+            final int at = config.getTierUpgradeEmerald2Seconds();
+            final long rem = Math.max(0, at - elapsedSeconds);
+            return ChatColor.WHITE + "Emerald II in " + ChatColor.GREEN + formatTime(rem);
+        }
+        if (diamondTier < 3) {
+            final int at = config.getTierUpgradeDiamond3Seconds();
+            final long rem = Math.max(0, at - elapsedSeconds);
+            return ChatColor.WHITE + "Diamond III in " + ChatColor.GREEN + formatTime(rem);
+        }
+        if (emeraldTier < 3) {
+            final int at = config.getTierUpgradeEmerald3Seconds();
+            final long rem = Math.max(0, at - elapsedSeconds);
+            return ChatColor.WHITE + "Emerald III in " + ChatColor.GREEN + formatTime(rem);
+        }
+        if (generatorPhase == GeneratorPhase.NORMAL) {
+            final int at = config.getTierUpgradeBedBreakSeconds();
+            final long rem = Math.max(0, at - elapsedSeconds);
+            return ChatColor.WHITE + "Bed Break in " + ChatColor.GREEN + formatTime(rem);
+        }
+        if (generatorPhase == GeneratorPhase.BED_BREAK) {
+            final int at = config.getTierUpgradeSuddenDeathSeconds();
+            final long rem = Math.max(0, at - elapsedSeconds);
+            return ChatColor.WHITE + "Sudden Death in " + ChatColor.GREEN + formatTime(rem);
+        }
+        return ChatColor.GRAY + "Sudden Death";
+    }
+
+    private static String formatTime(final long totalSeconds) {
+        final long m = totalSeconds / 60;
+        final long s = totalSeconds % 60;
+        return m + ":" + (s < 10 ? "0" : "") + s;
+    }
+
+    @Override
+    public void recordKill(final UUID killerUniqueId) {
+        if (killerUniqueId == null) return;
+        killCountThisGame.merge(killerUniqueId, 1, Integer::sum);
+    }
+
+    @Override
+    public void broadcastGameOverSummary(final ITeam winningTeam) {
+        final String separator = ChatColor.GREEN + "▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬";
+        for (Player p : getPlayers()) {
+            p.sendMessage(separator);
+            p.sendMessage(ChatColor.WHITE + "Bed Wars");
+            if (winningTeam != null) {
+                final String colorName = winningTeam.getColor().name().charAt(0) + winningTeam.getColor().name().substring(1).toLowerCase(Locale.ROOT);
+                final String names = String.join(", ", winningTeam.getOnlineMembers().stream().map(Player::getName).toList());
+                p.sendMessage(ChatColor.WHITE + colorName + " - " + names);
+            }
+            sendKillerStats(p);
+            p.sendMessage(separator);
+        }
+        for (Player p : getSpectators()) {
+            p.sendMessage(separator);
+            p.sendMessage(ChatColor.WHITE + "Bed Wars");
+            if (winningTeam != null) {
+                final String colorName = winningTeam.getColor().name().charAt(0) + winningTeam.getColor().name().substring(1).toLowerCase(Locale.ROOT);
+                final String names = String.join(", ", winningTeam.getOnlineMembers().stream().map(Player::getName).toList());
+                p.sendMessage(ChatColor.WHITE + colorName + " - " + names);
+            }
+            sendKillerStats(p);
+            p.sendMessage(separator);
+        }
+    }
+
+    private void sendKillerStats(final Player recipient) {
+        final List<Player> all = new ArrayList<>();
+        all.addAll(getPlayers());
+        all.addAll(getSpectators());
+        all.removeIf(p -> killCountThisGame.getOrDefault(p.getUniqueId(), 0) <= 0);
+        all.sort(Comparator.comparingInt(p -> -killCountThisGame.getOrDefault(p.getUniqueId(), 0)));
+        final ChatColor[] rankColors = { ChatColor.YELLOW, ChatColor.GOLD, ChatColor.RED };
+        for (int i = 0; i < Math.min(3, all.size()); i++) {
+            final Player p = all.get(i);
+            final int count = killCountThisGame.getOrDefault(p.getUniqueId(), 0);
+            final String rank = (i + 1) + (i == 0 ? "st" : i == 1 ? "nd" : "rd");
+            recipient.sendMessage(rankColors[i] + rank + " Killer - " + ChatColor.WHITE + p.getName() + " - " + count);
+        }
     }
 
     // --- Kit state for shop upgrades (armor/axe/pickaxe persist; sword resets on death) ---
@@ -636,14 +911,26 @@ public final class Arena implements IArena {
         final Optional<ITeam> teamOpt = getTeam(player);
         final ETeamColor color = teamOpt.map(ITeam::getColor).orElse(ETeamColor.WHITE);
         final ArmorTier tier = getPlayerArmorTier(player);
+        final TeamUpgradeState upgradeState = teamOpt.map(this::getTeamUpgradeState).orElse(null);
+        final int protLevel = upgradeState != null ? upgradeState.getProtection() : 0;
 
         final ItemStack chest = unbreakable(new ItemStack(Material.LEATHER_CHESTPLATE));
         final ItemStack helmet = unbreakable(new ItemStack(Material.LEATHER_HELMET));
         setLeatherColor(chest, color);
         setLeatherColor(helmet, color);
+        if (protLevel > 0) {
+            chest.addUnsafeEnchantment(Enchantment.PROTECTION, protLevel);
+            helmet.addUnsafeEnchantment(Enchantment.PROTECTION, protLevel);
+        }
 
         final ItemStack legs = unbreakable(new ItemStack(tier.getLeggings()));
         final ItemStack boots = unbreakable(new ItemStack(tier.getBoots()));
+        setLeatherColor(legs, color);
+        setLeatherColor(boots, color);
+        if (protLevel > 0) {
+            legs.addUnsafeEnchantment(Enchantment.PROTECTION, protLevel);
+            boots.addUnsafeEnchantment(Enchantment.PROTECTION, protLevel);
+        }
 
         player.getInventory().setChestplate(chest);
         player.getInventory().setHelmet(helmet);
@@ -676,7 +963,131 @@ public final class Arena implements IArena {
             if (s != null && isSword(s.getType())) count += s.getAmount();
         }
         if (count < 1) {
-            player.getInventory().addItem(unbreakable(new ItemStack(Material.WOODEN_SWORD)));
+            final ItemStack sword = unbreakable(new ItemStack(Material.WOODEN_SWORD));
+            applySharpnessIfTeamHas(player, sword);
+            player.getInventory().addItem(sword);
+        } else {
+            applySharpnessToAllSwords(player);
+        }
+    }
+
+    /** Applies Protection to current armor and Sharpness to all swords based on team upgrades. Call after shop buy or when reapplying. */
+    public void applyTeamUpgradesToInventory(final Player player) {
+        final Optional<ITeam> teamOpt = getTeam(player);
+        if (teamOpt.isEmpty()) return;
+        final TeamUpgradeState state = getTeamUpgradeState(teamOpt.get());
+        if (state == null) return;
+        final int prot = state.getProtection();
+        if (prot > 0) {
+            for (ItemStack piece : new ItemStack[]{
+                    player.getInventory().getHelmet(),
+                    player.getInventory().getChestplate(),
+                    player.getInventory().getLeggings(),
+                    player.getInventory().getBoots()
+            }) {
+                if (piece != null && !piece.getType().isAir() && piece.getType().getEquipmentSlot() != null) {
+                    piece.addUnsafeEnchantment(Enchantment.PROTECTION, prot);
+                }
+            }
+        }
+        applySharpnessToAllSwords(player);
+    }
+
+    private void applySharpnessToAllSwords(final Player player) {
+        final Optional<ITeam> teamOpt = getTeam(player);
+        if (teamOpt.isEmpty()) return;
+        if (!getTeamUpgradeState(teamOpt.get()).hasSharpness()) return;
+        for (ItemStack s : player.getInventory().getContents()) {
+            if (s != null && isSword(s.getType()) && !s.getEnchantments().containsKey(Enchantment.SHARPNESS)) {
+                s.addUnsafeEnchantment(Enchantment.SHARPNESS, 1);
+            }
+        }
+    }
+
+    private void applySharpnessIfTeamHas(final Player player, final ItemStack sword) {
+        final Optional<ITeam> teamOpt = getTeam(player);
+        if (teamOpt.isEmpty()) return;
+        if (getTeamUpgradeState(teamOpt.get()).hasSharpness()) {
+            sword.addUnsafeEnchantment(Enchantment.SHARPNESS, 1);
+        }
+    }
+
+    /**
+     * Call when a player moves. If they entered an enemy base and that team has a trap, trigger it.
+     */
+    public void checkTrapTrigger(final Player player) {
+        if (gameState != EGameState.IN_GAME && gameState != EGameState.ENDING) return;
+        final Optional<ITeam> playerTeamOpt = getTeam(player);
+        if (playerTeamOpt.isEmpty()) return;
+        final ITeam playerTeam = playerTeamOpt.get();
+        final Location loc = player.getLocation();
+        if (loc.getWorld() == null || !loc.getWorld().equals(world)) return;
+
+        for (ITeam team : teams) {
+            if (team.getId().equals(playerTeam.getId()) || team.isBedDestroyed()) continue;
+            final Location bed = team.getBedLocation();
+            if (bed == null || bed.getWorld() == null || !bed.getWorld().equals(world)) continue;
+            final boolean inBase = loc.distanceSquared(bed) <= (BASE_TRAP_RADIUS * BASE_TRAP_RADIUS);
+            final Set<UUID> inside = playersInsideEnemyBase.computeIfAbsent(team.getId(), k -> new HashSet<>());
+            if (inBase) {
+                if (!inside.contains(player.getUniqueId())) {
+                    inside.add(player.getUniqueId());
+                    triggerTrap(team, player);
+                }
+            } else {
+                inside.remove(player.getUniqueId());
+            }
+        }
+    }
+
+    private void triggerTrap(final ITeam defendingTeam, final Player enemy) {
+        final TeamUpgradeState state = getTeamUpgradeState(defendingTeam);
+        if (state == null) return;
+        final TrapType trap = state.consumeNextTrap();
+        if (trap == null) return;
+        switch (trap) {
+            case ITS_A_TRAP -> {
+                enemy.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 8 * 20, 0));
+                enemy.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS, 8 * 20, 0));
+            }
+            case COUNTER_OFFENSIVE -> {
+                for (Player p : defendingTeam.getOnlineMembers()) {
+                    if (p.getWorld().equals(world) && p.getLocation().distanceSquared(defendingTeam.getBedLocation()) <= (BASE_TRAP_RADIUS * BASE_TRAP_RADIUS)) {
+                        p.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 10 * 20, 0));
+                        p.addPotionEffect(new PotionEffect(PotionEffectType.JUMP_BOOST, 10 * 20, 1));
+                    }
+                }
+            }
+            case ALARM -> {
+                enemy.removePotionEffect(PotionEffectType.INVISIBILITY);
+                for (Player p : defendingTeam.getOnlineMembers()) {
+                    p.playSound(p.getLocation(), Sound.BLOCK_NOTE_BLOCK_BELL, 1f, 1f);
+                }
+            }
+            case MINER_FATIGUE -> {
+                enemy.addPotionEffect(new PotionEffect(PotionEffectType.MINING_FATIGUE, 10 * 20, 0));
+            }
+            default -> { }
+        }
+    }
+
+    /** Applies Haste (if team has it) and Regeneration at base (if team has Heal Pool). Call periodically. */
+    public void applyHasteAndHealPool(final Player player) {
+        if (gameState != EGameState.IN_GAME && gameState != EGameState.ENDING) return;
+        final Optional<ITeam> teamOpt = getTeam(player);
+        if (teamOpt.isEmpty()) return;
+        final TeamUpgradeState state = getTeamUpgradeState(teamOpt.get());
+        if (state == null) return;
+        final int haste = state.getHaste();
+        if (haste > 0) {
+            player.addPotionEffect(new PotionEffect(PotionEffectType.HASTE, 60, haste - 1, true, false));
+        }
+        if (state.hasHealPool()) {
+            final Location spawn = teamOpt.get().getSpawnLocation();
+            if (spawn != null && spawn.getWorld() != null && player.getWorld().equals(spawn.getWorld())
+                    && player.getLocation().distanceSquared(spawn) <= (HEAL_POOL_RADIUS * HEAL_POOL_RADIUS)) {
+                player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, 60, 0, true, false));
+            }
         }
     }
 

--- a/src/main/java/com/kartersanamo/bedwars/arena/ArenaManager.java
+++ b/src/main/java/com/kartersanamo/bedwars/arena/ArenaManager.java
@@ -7,11 +7,12 @@ import com.kartersanamo.bedwars.configuration.MainConfig;
 import com.kartersanamo.bedwars.configuration.GeneratorsConfig;
 import com.kartersanamo.bedwars.maprestore.InternalAdapter;
 import com.kartersanamo.bedwars.api.arena.generator.EGeneratorType;
-import com.kartersanamo.bedwars.arena.OreGenerator;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -109,13 +110,16 @@ public final class ArenaManager {
 
             // Create generators and spawn shop NPCs from configuration.
             for (ArenaConfig.TeamDefinition teamDef : config.getTeamDefinitions()) {
+                final Location forwardTarget = new Location(world,
+                        teamDef.getSpawn().getX(), teamDef.getSpawn().getY(), teamDef.getSpawn().getZ());
                 for (Location loc : teamDef.getIronGenerators()) {
                     arena.addGenerator(new OreGenerator(
                             arena,
                             EGeneratorType.IRON,
                             new Location(world, loc.getX(), loc.getY(), loc.getZ()),
                             generatorsConfig.getIronIntervalTicks(),
-                            mainConfig.getGeneratorMaxItems(teamSize, EGeneratorType.IRON)
+                            mainConfig.getGeneratorMaxItems(teamSize, EGeneratorType.IRON),
+                            forwardTarget
                     ));
                 }
                 for (Location loc : teamDef.getGoldGenerators()) {
@@ -124,7 +128,8 @@ public final class ArenaManager {
                             EGeneratorType.GOLD,
                             new Location(world, loc.getX(), loc.getY(), loc.getZ()),
                             generatorsConfig.getGoldIntervalTicks(),
-                            mainConfig.getGeneratorMaxItems(teamSize, EGeneratorType.GOLD)
+                            mainConfig.getGeneratorMaxItems(teamSize, EGeneratorType.GOLD),
+                            forwardTarget
                     ));
                 }
 
@@ -139,6 +144,54 @@ public final class ArenaManager {
                         villager.setSilent(true);
                         villager.setCustomNameVisible(true);
                         villager.setCustomName(teamDef.getColor().getChatColor() + "Item Shop");
+                    });
+                    final double x = npcLoc.getX();
+                    final double y = npcLoc.getY();
+                    final double z = npcLoc.getZ();
+                    world.spawn(new Location(world, x, y + 2.0, z), ArmorStand.class, stand -> {
+                        stand.setMarker(true);
+                        stand.setInvisible(true);
+                        stand.setGravity(false);
+                        stand.setCustomNameVisible(true);
+                        stand.setCustomName(ChatColor.GREEN + "ITEM SHOP");
+                    });
+                    world.spawn(new Location(world, x, y + 1.75, z), ArmorStand.class, stand -> {
+                        stand.setMarker(true);
+                        stand.setInvisible(true);
+                        stand.setGravity(false);
+                        stand.setCustomNameVisible(true);
+                        stand.setCustomName(ChatColor.GOLD + "RIGHT CLICK");
+                    });
+                }
+
+                final Location upgradeNpcLocation = teamDef.getUpgradeNpc();
+                if (upgradeNpcLocation != null && upgradeNpcLocation.getWorld() != null) {
+                    final Location upgLoc = new Location(world, upgradeNpcLocation.getX(), upgradeNpcLocation.getY(),
+                            upgradeNpcLocation.getZ(), upgradeNpcLocation.getYaw(), upgradeNpcLocation.getPitch());
+                    world.spawn(upgLoc, Villager.class, villager -> {
+                        villager.setAI(false);
+                        villager.setCollidable(false);
+                        villager.setInvulnerable(true);
+                        villager.setSilent(true);
+                        villager.setCustomNameVisible(true);
+                        villager.setCustomName(teamDef.getColor().getChatColor() + "Upgrades");
+                    });
+                    final double ux = upgLoc.getX();
+                    final double uy = upgLoc.getY();
+                    final double uz = upgLoc.getZ();
+                    world.spawn(new Location(world, ux, uy + 2.0, uz), ArmorStand.class, stand -> {
+                        stand.setMarker(true);
+                        stand.setInvisible(true);
+                        stand.setGravity(false);
+                        stand.setCustomNameVisible(true);
+                        stand.setCustomName(ChatColor.GREEN + "UPGRADES");
+                    });
+                    world.spawn(new Location(world, ux, uy + 1.75, uz), ArmorStand.class, stand -> {
+                        stand.setMarker(true);
+                        stand.setInvisible(true);
+                        stand.setGravity(false);
+                        stand.setCustomNameVisible(true);
+                        stand.setCustomName(ChatColor.GOLD + "RIGHT CLICK");
                     });
                 }
             }

--- a/src/main/java/com/kartersanamo/bedwars/arena/GeneratorPhase.java
+++ b/src/main/java/com/kartersanamo/bedwars/arena/GeneratorPhase.java
@@ -1,0 +1,11 @@
+package com.kartersanamo.bedwars.arena;
+
+/**
+ * Game phase for generator tier progression: NORMAL (tiers upgrading),
+ * BED_BREAK (announced), SUDDEN_DEATH (final phase).
+ */
+public enum GeneratorPhase {
+    NORMAL,
+    BED_BREAK,
+    SUDDEN_DEATH
+}

--- a/src/main/java/com/kartersanamo/bedwars/arena/OreGenerator.java
+++ b/src/main/java/com/kartersanamo/bedwars/arena/OreGenerator.java
@@ -9,15 +9,19 @@ import org.bukkit.entity.Item;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Basic implementation of a resource generator.
+ * Iron and gold generators may have a forward target (team spawn) for block-placement protection.
  */
 public final class OreGenerator implements IGenerator {
 
     private final IArena arena;
     private final EGeneratorType type;
     private final Location location;
+
+    private final Location forwardTarget;
 
     private final int intervalTicks;
     private final int maxItems;
@@ -29,11 +33,28 @@ public final class OreGenerator implements IGenerator {
                         final Location location,
                         final int intervalTicks,
                         final int maxItems) {
+        this(arena, type, location, intervalTicks, maxItems, null);
+    }
+
+    public OreGenerator(final IArena arena,
+                        final EGeneratorType type,
+                        final Location location,
+                        final int intervalTicks,
+                        final int maxItems,
+                        final Location forwardTarget) {
         this.arena = Objects.requireNonNull(arena, "arena");
         this.type = Objects.requireNonNull(type, "type");
         this.location = Objects.requireNonNull(location, "location").clone();
         this.intervalTicks = intervalTicks;
         this.maxItems = maxItems;
+        this.forwardTarget = forwardTarget != null ? forwardTarget.clone() : null;
+    }
+
+    /**
+     * For iron/gold generators, the location (e.g. team spawn) that defines "forward" for protection.
+     */
+    public Optional<Location> getForwardTarget() {
+        return forwardTarget == null ? Optional.empty() : Optional.of(forwardTarget.clone());
     }
 
     @Override
@@ -55,17 +76,27 @@ public final class OreGenerator implements IGenerator {
         return intervalTicks;
     }
 
+    private int getEffectiveIntervalTicks() {
+        if (type == EGeneratorType.DIAMOND || type == EGeneratorType.EMERALD) {
+            return type == EGeneratorType.DIAMOND
+                    ? arena.getEffectiveDiamondIntervalTicks()
+                    : arena.getEffectiveEmeraldIntervalTicks();
+        }
+        return intervalTicks;
+    }
+
     public long getLastDropTick() {
         return lastDropTick;
     }
 
     @Override
     public void tick(final long currentTick) {
-        if (intervalTicks <= 0) {
+        final int effectiveInterval = getEffectiveIntervalTicks();
+        if (effectiveInterval <= 0) {
             return;
         }
 
-        if (currentTick - lastDropTick < intervalTicks) {
+        if (currentTick - lastDropTick < effectiveInterval) {
             return;
         }
 
@@ -79,6 +110,7 @@ public final class OreGenerator implements IGenerator {
                 .count();
 
         if (nearbyCount >= maxItems) {
+            lastDropTick = currentTick;
             return;
         }
 

--- a/src/main/java/com/kartersanamo/bedwars/arena/tasks/GamePlayingTask.java
+++ b/src/main/java/com/kartersanamo/bedwars/arena/tasks/GamePlayingTask.java
@@ -34,9 +34,10 @@ public final class GamePlayingTask extends BukkitRunnable {
 
         if (aliveTeams.size() <= 1) {
             arena.setGameState(EGameState.ENDING);
+            final ITeam winningTeam = aliveTeams.isEmpty() ? null : aliveTeams.get(0);
+            arena.broadcastGameOverSummary(winningTeam);
 
-            if (!aliveTeams.isEmpty()) {
-                final ITeam winningTeam = aliveTeams.get(0);
+            if (winningTeam != null) {
                 for (Player player : winningTeam.getOnlineMembers()) {
                     player.sendTitle("Victory!", "", 10, 60, 10);
                 }

--- a/src/main/java/com/kartersanamo/bedwars/arena/tasks/GameStartingTask.java
+++ b/src/main/java/com/kartersanamo/bedwars/arena/tasks/GameStartingTask.java
@@ -2,7 +2,6 @@ package com.kartersanamo.bedwars.arena.tasks;
 
 import com.kartersanamo.bedwars.api.arena.EGameState;
 import com.kartersanamo.bedwars.api.arena.IArena;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -54,17 +53,27 @@ public final class GameStartingTask extends BukkitRunnable {
             return;
         }
 
-        // Announce only milestone seconds in chat.
-        if (secondsRemaining == 15
+        // Announce milestone seconds in chat and show big number as title.
+        if (secondsRemaining == 20
+                || secondsRemaining == 15
                 || secondsRemaining == 10
                 || secondsRemaining == 5
+                || secondsRemaining == 4
                 || secondsRemaining == 3
                 || secondsRemaining == 2
                 || secondsRemaining == 1) {
-            final String message = ChatColor.GREEN + "Game starting in " + secondsRemaining + " second"
-                    + (secondsRemaining == 1 ? "" : "s") + "...";
+            final ChatColor numberColor = secondsRemaining <= 5 ? ChatColor.RED : ChatColor.GOLD;
+            final String unit = secondsRemaining == 1 ? " second!" : " seconds!";
+            final String message = ChatColor.GOLD + "The game starts in " + numberColor + secondsRemaining
+                    + ChatColor.GOLD + unit;
+            final String subtitle = secondsRemaining == 1 ? "second" : "seconds";
             for (Player player : arena.getPlayers()) {
                 player.sendMessage(message);
+                player.sendTitle(
+                        numberColor.toString() + secondsRemaining,
+                        ChatColor.GRAY + subtitle,
+                        5, 25, 5
+                );
             }
         }
 

--- a/src/main/java/com/kartersanamo/bedwars/arena/tasks/UpgradesApplyTask.java
+++ b/src/main/java/com/kartersanamo/bedwars/arena/tasks/UpgradesApplyTask.java
@@ -1,0 +1,30 @@
+package com.kartersanamo.bedwars.arena.tasks;
+
+import com.kartersanamo.bedwars.api.arena.IArena;
+import com.kartersanamo.bedwars.arena.Arena;
+import com.kartersanamo.bedwars.arena.ArenaManager;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+/**
+ * Periodically applies Haste and Heal Pool effects to players based on team upgrades.
+ */
+public final class UpgradesApplyTask extends BukkitRunnable {
+
+    private final ArenaManager arenaManager;
+
+    public UpgradesApplyTask(final JavaPlugin plugin, final ArenaManager arenaManager) {
+        this.arenaManager = arenaManager;
+    }
+
+    @Override
+    public void run() {
+        for (IArena arena : arenaManager.getArenas()) {
+            if (!(arena instanceof Arena concreteArena)) continue;
+            for (Player player : arena.getPlayers()) {
+                concreteArena.applyHasteAndHealPool(player);
+            }
+        }
+    }
+}

--- a/src/main/java/com/kartersanamo/bedwars/configuration/ArenaConfig.java
+++ b/src/main/java/com/kartersanamo/bedwars/configuration/ArenaConfig.java
@@ -108,8 +108,9 @@ public final class ArenaConfig {
             final List<Location> ironGenerators = readLocationList(ConfigPath.Arena.TEAMS + "." + teamId + "." + ConfigPath.Arena.TEAM_IRON_GENERATORS);
             final List<Location> goldGenerators = readLocationList(ConfigPath.Arena.TEAMS + "." + teamId + "." + ConfigPath.Arena.TEAM_GOLD_GENERATORS);
             final Location shopNpc = readLocation(ConfigPath.Arena.TEAMS + "." + teamId + "." + ConfigPath.Arena.TEAM_SHOP_NPC);
+            final Location upgradeNpc = readLocation(ConfigPath.Arena.TEAMS + "." + teamId + "." + ConfigPath.Arena.TEAM_UPGRADE_NPC);
 
-            result.add(new TeamDefinition(teamId, color, spawn, bed, ironGenerators, goldGenerators, shopNpc));
+            result.add(new TeamDefinition(teamId, color, spawn, bed, ironGenerators, goldGenerators, shopNpc, upgradeNpc));
         }
 
         return result;
@@ -218,6 +219,7 @@ public final class ArenaConfig {
         private final List<Location> ironGenerators;
         private final List<Location> goldGenerators;
         private final Location shopNpc;
+        private final Location upgradeNpc;
 
         public TeamDefinition(final String id,
                               final ETeamColor color,
@@ -225,7 +227,8 @@ public final class ArenaConfig {
                               final Location bed,
                               final List<Location> ironGenerators,
                               final List<Location> goldGenerators,
-                              final Location shopNpc) {
+                              final Location shopNpc,
+                              final Location upgradeNpc) {
             this.id = id;
             this.color = color;
             this.spawn = spawn;
@@ -233,6 +236,7 @@ public final class ArenaConfig {
             this.ironGenerators = Collections.unmodifiableList(new ArrayList<>(ironGenerators));
             this.goldGenerators = Collections.unmodifiableList(new ArrayList<>(goldGenerators));
             this.shopNpc = shopNpc;
+            this.upgradeNpc = upgradeNpc;
         }
 
         public String getId() {
@@ -261,6 +265,10 @@ public final class ArenaConfig {
 
         public Location getShopNpc() {
             return shopNpc;
+        }
+
+        public Location getUpgradeNpc() {
+            return upgradeNpc;
         }
     }
 

--- a/src/main/java/com/kartersanamo/bedwars/configuration/GeneratorsConfig.java
+++ b/src/main/java/com/kartersanamo/bedwars/configuration/GeneratorsConfig.java
@@ -35,6 +35,18 @@ public final class GeneratorsConfig {
         configuration.addDefault(ConfigPath.Generators.EMERALD_INTERVAL_TICKS, 1200);
         configuration.addDefault(ConfigPath.Generators.EMERALD_MAX_ITEMS, 16);
 
+        configuration.addDefault(ConfigPath.Generators.TIER_UPGRADE_DIAMOND_2, 300);
+        configuration.addDefault(ConfigPath.Generators.TIER_UPGRADE_EMERALD_2, 480);
+        configuration.addDefault(ConfigPath.Generators.TIER_UPGRADE_DIAMOND_3, 660);
+        configuration.addDefault(ConfigPath.Generators.TIER_UPGRADE_EMERALD_3, 840);
+        configuration.addDefault(ConfigPath.Generators.TIER_UPGRADE_BED_BREAK, 900);
+        configuration.addDefault(ConfigPath.Generators.TIER_UPGRADE_SUDDEN_DEATH, 960);
+
+        configuration.addDefault(ConfigPath.Generators.DIAMOND_TIER_2_INTERVAL_TICKS, 400);
+        configuration.addDefault(ConfigPath.Generators.DIAMOND_TIER_3_INTERVAL_TICKS, 200);
+        configuration.addDefault(ConfigPath.Generators.EMERALD_TIER_2_INTERVAL_TICKS, 800);
+        configuration.addDefault(ConfigPath.Generators.EMERALD_TIER_3_INTERVAL_TICKS, 400);
+
         configuration.options().copyDefaults(true);
     }
 
@@ -68,5 +80,45 @@ public final class GeneratorsConfig {
 
     public int getEmeraldMaxItems() {
         return configuration.getInt(ConfigPath.Generators.EMERALD_MAX_ITEMS, 16);
+    }
+
+    public int getTierUpgradeDiamond2Seconds() {
+        return configuration.getInt(ConfigPath.Generators.TIER_UPGRADE_DIAMOND_2, 300);
+    }
+
+    public int getTierUpgradeEmerald2Seconds() {
+        return configuration.getInt(ConfigPath.Generators.TIER_UPGRADE_EMERALD_2, 480);
+    }
+
+    public int getTierUpgradeDiamond3Seconds() {
+        return configuration.getInt(ConfigPath.Generators.TIER_UPGRADE_DIAMOND_3, 660);
+    }
+
+    public int getTierUpgradeEmerald3Seconds() {
+        return configuration.getInt(ConfigPath.Generators.TIER_UPGRADE_EMERALD_3, 840);
+    }
+
+    public int getTierUpgradeBedBreakSeconds() {
+        return configuration.getInt(ConfigPath.Generators.TIER_UPGRADE_BED_BREAK, 900);
+    }
+
+    public int getTierUpgradeSuddenDeathSeconds() {
+        return configuration.getInt(ConfigPath.Generators.TIER_UPGRADE_SUDDEN_DEATH, 960);
+    }
+
+    public int getDiamondTier2IntervalTicks() {
+        return configuration.getInt(ConfigPath.Generators.DIAMOND_TIER_2_INTERVAL_TICKS, 400);
+    }
+
+    public int getDiamondTier3IntervalTicks() {
+        return configuration.getInt(ConfigPath.Generators.DIAMOND_TIER_3_INTERVAL_TICKS, 200);
+    }
+
+    public int getEmeraldTier2IntervalTicks() {
+        return configuration.getInt(ConfigPath.Generators.EMERALD_TIER_2_INTERVAL_TICKS, 800);
+    }
+
+    public int getEmeraldTier3IntervalTicks() {
+        return configuration.getInt(ConfigPath.Generators.EMERALD_TIER_3_INTERVAL_TICKS, 400);
     }
 }

--- a/src/main/java/com/kartersanamo/bedwars/configuration/MainConfig.java
+++ b/src/main/java/com/kartersanamo/bedwars/configuration/MainConfig.java
@@ -36,25 +36,26 @@ public final class MainConfig {
         configuration.addDefault(ConfigPath.Main.GAME_VOID_Y, 0);
 
         // Default generator caps per game mode (can be overridden in config.yml).
-        // Values are per-generator item caps on the ground.
+        // Max dropped items per generator on the ground; when reached, generator stops until items are picked up.
+        // Spawn island (iron/gold): 48 iron, 12 gold per generator. Mid: 4 diamonds, 2 emeralds per generator.
         // Solo
         configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_SOLO_IRON, 48);
-        configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_SOLO_GOLD, 8);
+        configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_SOLO_GOLD, 12);
         configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_SOLO_DIAMOND, 4);
         configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_SOLO_EMERALD, 2);
         // Doubles
         configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_DOUBLES_IRON, 48);
-        configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_DOUBLES_GOLD, 8);
+        configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_DOUBLES_GOLD, 12);
         configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_DOUBLES_DIAMOND, 4);
         configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_DOUBLES_EMERALD, 2);
         // Threes
         configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_THREES_IRON, 48);
-        configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_THREES_GOLD, 8);
+        configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_THREES_GOLD, 12);
         configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_THREES_DIAMOND, 4);
         configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_THREES_EMERALD, 2);
         // Fours
         configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_FOURS_IRON, 48);
-        configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_FOURS_GOLD, 8);
+        configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_FOURS_GOLD, 12);
         configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_FOURS_DIAMOND, 4);
         configuration.addDefault(ConfigPath.Main.GENERATOR_CAPS_FOURS_EMERALD, 2);
 

--- a/src/main/java/com/kartersanamo/bedwars/gui/GameModeGuiListener.java
+++ b/src/main/java/com/kartersanamo/bedwars/gui/GameModeGuiListener.java
@@ -74,8 +74,10 @@ public final class GameModeGuiListener implements Listener {
         player.teleport(arena.getLobbySpawn());
         final int current = arena.getPlayers().size();
         final int max = arena.getMaxPlayers();
+        final String joinMessage = ChatColor.YELLOW + player.getName() + ChatColor.GRAY + " has joined "
+                + ChatColor.AQUA + "(" + current + "/" + max + ")!";
         for (Player other : arena.getPlayers()) {
-            other.sendMessage(player.getName() + " joined the game (" + current + "/" + max + ").");
+            other.sendMessage(joinMessage);
         }
 
         arena.tryStartCountdown();

--- a/src/main/java/com/kartersanamo/bedwars/hologram/HologramManager.java
+++ b/src/main/java/com/kartersanamo/bedwars/hologram/HologramManager.java
@@ -1,13 +1,17 @@
 package com.kartersanamo.bedwars.hologram;
 
 import com.kartersanamo.bedwars.Bedwars;
+import com.kartersanamo.bedwars.api.arena.EGameState;
 import com.kartersanamo.bedwars.api.arena.generator.EGeneratorType;
 import com.kartersanamo.bedwars.api.arena.generator.IGenerator;
 import com.kartersanamo.bedwars.arena.OreGenerator;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.EulerAngle;
 
 import java.util.*;
 
@@ -18,6 +22,7 @@ public final class HologramManager {
 
     private final Bedwars plugin;
     private final Map<IGenerator, List<ArmorStand>> hologramsByGenerator = new HashMap<>();
+    private final Map<IGenerator, ArmorStand> rotatingBlockByGenerator = new HashMap<>();
 
     public HologramManager(final Bedwars plugin) {
         this.plugin = plugin;
@@ -25,6 +30,9 @@ public final class HologramManager {
 
     public void update(final long currentTick) {
         plugin.getArenaManager().getArenas().forEach(arena -> {
+            if (arena.getGameState() != EGameState.IN_GAME) {
+                return;
+            }
             for (IGenerator generator : arena.getGenerators()) {
                 final EGeneratorType type = generator.getType();
                 if (type != EGeneratorType.DIAMOND && type != EGeneratorType.EMERALD) {
@@ -33,6 +41,11 @@ public final class HologramManager {
 
                 final List<ArmorStand> stands = hologramsByGenerator.computeIfAbsent(generator, g -> createHologram(g));
                 updateHologramLines(stands, generator, currentTick);
+                final ArmorStand rotatingBlock = rotatingBlockByGenerator.computeIfAbsent(generator, this::createRotatingBlock);
+                if (rotatingBlock != null && !rotatingBlock.isDead()) {
+                    final double angleDeg = (currentTick * 4) % 360;
+                    rotatingBlock.setHeadPose(new EulerAngle(0, Math.toRadians(angleDeg), 0));
+                }
             }
         });
     }
@@ -46,6 +59,12 @@ public final class HologramManager {
             }
         }
         hologramsByGenerator.clear();
+        for (ArmorStand stand : rotatingBlockByGenerator.values()) {
+            if (stand != null && !stand.isDead()) {
+                stand.remove();
+            }
+        }
+        rotatingBlockByGenerator.clear();
     }
 
     private List<ArmorStand> createHologram(final IGenerator generator) {
@@ -56,9 +75,9 @@ public final class HologramManager {
         }
 
         final List<ArmorStand> result = new ArrayList<>(3);
-        final double x = base.getX() + 0.5;
-        double y = base.getY() + 2.2;
-        final double z = base.getZ() + 0.5;
+        final double x = base.getBlockX() + 0.5;
+        final double y = base.getBlockY() + 4.2;
+        final double z = base.getBlockZ() + 0.5;
 
         for (int i = 0; i < 3; i++) {
             final Location loc = new Location(world, x, y - (0.25 * i), z);
@@ -74,24 +93,49 @@ public final class HologramManager {
         return result;
     }
 
+    private ArmorStand createRotatingBlock(final IGenerator generator) {
+        final Location base = generator.getLocation();
+        final World world = base.getWorld();
+        if (world == null) {
+            return null;
+        }
+        final EGeneratorType type = generator.getType();
+        final Material block = type == EGeneratorType.EMERALD ? Material.EMERALD_BLOCK : Material.DIAMOND_BLOCK;
+        final double x = base.getBlockX() + 0.5;
+        final double y = base.getBlockY() + 2.5;
+        final double z = base.getBlockZ() + 0.5;
+        final ArmorStand stand = world.spawn(new Location(world, x, y, z), ArmorStand.class, armorStand -> {
+            armorStand.setMarker(true);
+            armorStand.setInvisible(true);
+            armorStand.setGravity(false);
+            armorStand.setBasePlate(false);
+            armorStand.setSmall(true);
+            armorStand.setHelmet(new ItemStack(block));
+        });
+        return stand;
+    }
+
     private void updateHologramLines(final List<ArmorStand> stands, final IGenerator generator, final long currentTick) {
         if (stands.isEmpty() || !(generator instanceof OreGenerator ore)) {
             return;
         }
 
         final EGeneratorType type = generator.getType();
-
-        // TODO: hook into real tier progression. For now, default everything to Tier I.
-        final int tier = 1;
+        final int tier = type == EGeneratorType.EMERALD
+                ? generator.getArena().getEmeraldTier()
+                : generator.getArena().getDiamondTier();
         final String tierRoman = toRoman(tier);
 
-        long interval = ore.getIntervalTicks();
+        long interval = type == EGeneratorType.EMERALD
+                ? generator.getArena().getEffectiveEmeraldIntervalTicks()
+                : generator.getArena().getEffectiveDiamondIntervalTicks();
         if (interval <= 0L) {
             interval = 20L;
         }
-        long lastDrop = ore.getLastDropTick();
-        long elapsed = lastDrop == 0L ? 0L : currentTick - lastDrop;
-        long remainingTicks = Math.max(0L, interval - elapsed);
+        final long lastDrop = ore.getLastDropTick();
+        // Time until next drop: from last drop (or full interval if never dropped)
+        final long elapsed = lastDrop == 0L ? 0L : (currentTick - lastDrop);
+        final long remainingTicks = lastDrop == 0L ? interval : Math.max(0L, interval - elapsed);
         final int remainingSeconds = (int) ((remainingTicks + 19L) / 20L);
 
         final String line1 = ChatColor.YELLOW + "Tier " + ChatColor.RED + tierRoman;

--- a/src/main/java/com/kartersanamo/bedwars/listeners/BlockPlaceListener.java
+++ b/src/main/java/com/kartersanamo/bedwars/listeners/BlockPlaceListener.java
@@ -2,19 +2,35 @@ package com.kartersanamo.bedwars.listeners;
 
 import com.kartersanamo.bedwars.Bedwars;
 import com.kartersanamo.bedwars.api.arena.IArena;
+import com.kartersanamo.bedwars.api.arena.generator.EGeneratorType;
+import com.kartersanamo.bedwars.api.arena.generator.IGenerator;
 import com.kartersanamo.bedwars.arena.Arena;
+import com.kartersanamo.bedwars.arena.OreGenerator;
 import com.kartersanamo.bedwars.maprestore.InternalAdapter;
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
 
 /**
  * Tracks block placements inside arenas so they can be restored later.
+ * Prevents placing blocks near generators (2 blocks horizontal, 5 up, 2 down).
+ * For iron/gold: also prevents placing 11 blocks in front (toward bed/spawn) and 7 blocks up.
  */
 public final class BlockPlaceListener implements Listener {
+
+    private static final int RADIUS_H = 2;
+    private static final int RANGE_UP = 5;
+    private static final int RANGE_DOWN = 2;
+
+    private static final int IRON_GOLD_FORWARD_BLOCKS = 11;
+    private static final int IRON_GOLD_UP_BLOCKS = 7;
+
+    private static final int NPC_PROTECTION_RADIUS = 3;
 
     private final Bedwars plugin;
 
@@ -36,7 +52,127 @@ public final class BlockPlaceListener implements Listener {
             return;
         }
 
+        if (isInsideGeneratorProtection(location, arena)) {
+            event.setCancelled(true);
+            return;
+        }
+        if (isInsideIronGoldForwardProtection(location, arena)) {
+            event.setCancelled(true);
+            return;
+        }
+        if (isWithinBlocksOfNpc(location, arena)) {
+            event.setCancelled(true);
+            return;
+        }
+
         final InternalAdapter adapter = plugin.getInternalAdapter();
         adapter.markModified(arena, block);
+    }
+
+    private boolean isInsideGeneratorProtection(final Location blockLoc, final IArena arena) {
+        if (blockLoc.getWorld() == null || !blockLoc.getWorld().equals(arena.getWorld())) {
+            return false;
+        }
+        final int bx = blockLoc.getBlockX();
+        final int by = blockLoc.getBlockY();
+        final int bz = blockLoc.getBlockZ();
+
+        for (IGenerator gen : arena.getGenerators()) {
+            final Location genLoc = gen.getLocation();
+            if (genLoc.getWorld() == null || !genLoc.getWorld().equals(blockLoc.getWorld())) {
+                continue;
+            }
+            final int gx = genLoc.getBlockX();
+            final int gy = genLoc.getBlockY();
+            final int gz = genLoc.getBlockZ();
+
+            if (bx >= gx - RADIUS_H && bx <= gx + RADIUS_H
+                    && by >= gy - RANGE_DOWN && by <= gy + RANGE_UP
+                    && bz >= gz - RADIUS_H && bz <= gz + RADIUS_H) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the block is in the protected lane: 11 blocks in front of an iron/gold
+     * generator (toward bed/spawn) and 7 blocks up from the generator's Y.
+     */
+    private boolean isInsideIronGoldForwardProtection(final Location blockLoc, final IArena arena) {
+        if (blockLoc.getWorld() == null || !blockLoc.getWorld().equals(arena.getWorld())) {
+            return false;
+        }
+        final int bx = blockLoc.getBlockX();
+        final int by = blockLoc.getBlockY();
+        final int bz = blockLoc.getBlockZ();
+
+        for (IGenerator gen : arena.getGenerators()) {
+            final EGeneratorType type = gen.getType();
+            if (type != EGeneratorType.IRON && type != EGeneratorType.GOLD) {
+                continue;
+            }
+            if (!(gen instanceof OreGenerator ore)) {
+                continue;
+            }
+            final var forwardOpt = ore.getForwardTarget();
+            if (forwardOpt.isEmpty()) {
+                continue;
+            }
+            final Location genLoc = ore.getLocation();
+            final Location targetLoc = forwardOpt.get();
+            if (genLoc.getWorld() == null || !genLoc.getWorld().equals(blockLoc.getWorld())) {
+                continue;
+            }
+            final int gx = genLoc.getBlockX();
+            final int gy = genLoc.getBlockY();
+            final int gz = genLoc.getBlockZ();
+
+            final double tx = targetLoc.getX();
+            final double tz = targetLoc.getZ();
+            final int dx = Math.abs(tx - gx) >= Math.abs(tz - gz) ? (tx > gx ? 1 : (tx < gx ? -1 : 0)) : 0;
+            final int dz = (dx == 0) ? (tz > gz ? 1 : (tz < gz ? -1 : 0)) : 0;
+            if (dx == 0 && dz == 0) {
+                continue;
+            }
+
+            if (by < gy || by > gy + IRON_GOLD_UP_BLOCKS) {
+                continue;
+            }
+            if (dx != 0) {
+                final int step = bx - gx;
+                if (step * dx >= 1 && step * dx <= IRON_GOLD_FORWARD_BLOCKS && bz == gz) {
+                    return true;
+                }
+            }
+            if (dz != 0) {
+                final int step = bz - gz;
+                if (step * dz >= 1 && step * dz <= IRON_GOLD_FORWARD_BLOCKS && bx == gx) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean isWithinBlocksOfNpc(final Location blockLoc, final IArena arena) {
+        final World world = arena.getWorld();
+        if (world == null || !world.equals(blockLoc.getWorld())) {
+            return false;
+        }
+        final int bx = blockLoc.getBlockX();
+        final int by = blockLoc.getBlockY();
+        final int bz = blockLoc.getBlockZ();
+
+        for (Villager villager : world.getEntitiesByClass(Villager.class)) {
+            final Location npcLoc = villager.getLocation();
+            final int dx = Math.abs(bx - npcLoc.getBlockX());
+            final int dy = Math.abs(by - npcLoc.getBlockY());
+            final int dz = Math.abs(bz - npcLoc.getBlockZ());
+            if (dx <= NPC_PROTECTION_RADIUS && dy <= NPC_PROTECTION_RADIUS && dz <= NPC_PROTECTION_RADIUS) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/kartersanamo/bedwars/listeners/DamageListener.java
+++ b/src/main/java/com/kartersanamo/bedwars/listeners/DamageListener.java
@@ -1,14 +1,20 @@
 package com.kartersanamo.bedwars.listeners;
 
 import com.kartersanamo.bedwars.Bedwars;
+import com.kartersanamo.bedwars.api.arena.EGameState;
 import com.kartersanamo.bedwars.api.arena.IArena;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 
 /**
  * Ensures damage logic is only customised for players inside arenas.
+ * Cancels all damage to players in the waiting lobby (LOBBY_WAITING or STARTING).
+ * For in-game players: if damage would be lethal, cancels the death and runs arena death
+ * (instant teleport to spectator, no death screen).
  */
 public final class DamageListener implements Listener {
 
@@ -29,7 +35,47 @@ public final class DamageListener implements Listener {
             return;
         }
 
-        // For the MVP we do not need to alter most damage,
-        // but this hook is available for future extensions.
+        final EGameState state = arena.getGameState();
+        if (state == EGameState.LOBBY_WAITING || state == EGameState.STARTING) {
+            event.setCancelled(true);
+            return;
+        }
+
+        if (arena.hasSpawnProtection(player)) {
+            event.setCancelled(true);
+            return;
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onLethalDamage(final EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof Player player)) {
+            return;
+        }
+
+        final IArena arena = plugin.getArenaManager().getArena(player);
+        if (arena == null) {
+            return;
+        }
+
+        if (arena.getGameState() != EGameState.IN_GAME && arena.getGameState() != EGameState.ENDING) {
+            return;
+        }
+
+        final double healthAfter = player.getHealth() - event.getFinalDamage();
+        if (healthAfter > 0) {
+            return;
+        }
+
+        event.setCancelled(true);
+
+        Player killer = null;
+        if (event instanceof EntityDamageByEntityEvent byEntity) {
+            if (byEntity.getDamager() instanceof Player damager) {
+                killer = damager;
+            }
+        }
+
+        DeathListener.handleArenaDeath(plugin, player, killer, arena);
     }
 }

--- a/src/main/java/com/kartersanamo/bedwars/listeners/DeathListener.java
+++ b/src/main/java/com/kartersanamo/bedwars/listeners/DeathListener.java
@@ -2,17 +2,33 @@ package com.kartersanamo.bedwars.listeners;
 
 import com.kartersanamo.bedwars.Bedwars;
 import com.kartersanamo.bedwars.api.arena.IArena;
-import com.kartersanamo.bedwars.database.Database;
+import com.kartersanamo.bedwars.api.arena.team.ITeam;
 import com.kartersanamo.bedwars.database.PlayerStats;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * Handles player deaths inside arenas and delegates to arena logic.
+ * Prevents death drops; gives victim's ores (iron, gold, diamond, emerald) to the killer.
  */
 public final class DeathListener implements Listener {
+
+    private static final Material[] ORE_MATERIALS = {
+            Material.IRON_INGOT,
+            Material.GOLD_INGOT,
+            Material.DIAMOND,
+            Material.EMERALD
+    };
 
     private final Bedwars plugin;
 
@@ -28,20 +44,80 @@ public final class DeathListener implements Listener {
             return;
         }
 
-        final Player killer = player.getKiller();
-        arena.handlePlayerDeath(player, killer);
+        event.getDrops().clear();
+        event.setDeathMessage(null);
+        handleArenaDeath(plugin, player, player.getKiller(), arena);
+    }
 
-        final Database database = plugin.getDatabase();
+    /**
+     * Performs full arena death handling: transfer ores to killer, arena death logic, stats.
+     * Call from DeathListener (real death) or DamageListener (fake death when damage would be lethal).
+     */
+    public static void handleArenaDeath(final Bedwars plugin, final Player victim, final Player killer, final IArena arena) {
+        if (killer != null && killer != victim && plugin.getArenaManager().getArena(killer) == arena) {
+            transferOresToKiller(victim, killer);
+        }
+        arena.handlePlayerDeath(victim, killer);
+        updateDeathStats(plugin, arena, victim, killer);
+        if (killer != null && killer != victim) {
+            arena.recordKill(killer.getUniqueId());
+            broadcastKillMessage(arena, victim, killer);
+        }
+    }
+
+    private static void broadcastKillMessage(final IArena arena, final Player victim, final Player killer) {
+        final boolean finalKill = arena.getTeam(victim).map(ITeam::isBedDestroyed).orElse(false);
+        final String message = ChatColor.RED + victim.getName() + ChatColor.WHITE + " was killed by " + killer.getName() + "."
+                + (finalKill ? " " + ChatColor.AQUA.toString() + ChatColor.BOLD + "FINAL KILL!" : "");
+        for (Player p : arena.getPlayers()) {
+            p.sendMessage(message);
+        }
+        for (Player p : arena.getSpectators()) {
+            p.sendMessage(message);
+        }
+    }
+
+    private static void updateDeathStats(final Bedwars plugin, final IArena arena, final Player victim, final Player killer) {
         try {
-            final PlayerStats victimStats = database.getCachedStats(player.getUniqueId(), player.getName());
+            final PlayerStats victimStats = plugin.getDatabase().getCachedStats(victim.getUniqueId(), victim.getName());
             victimStats.incrementDeaths();
-
-            if (killer != null && killer != player) {
-                final PlayerStats killerStats = database.getCachedStats(killer.getUniqueId(), killer.getName());
+            if (killer != null && killer != victim) {
+                final PlayerStats killerStats = plugin.getDatabase().getCachedStats(killer.getUniqueId(), killer.getName());
                 killerStats.incrementKills();
+                final boolean finalKill = arena.getTeam(victim).map(ITeam::isBedDestroyed).orElse(false);
+                if (finalKill) {
+                    killerStats.incrementFinalKills();
+                }
             }
         } catch (Exception ex) {
             plugin.getLogger().warning("Failed to update kill/death stats: " + ex.getMessage());
+        }
+    }
+
+    private static void transferOresToKiller(final Player victim, final Player killer) {
+        final List<ItemStack> ores = new ArrayList<>();
+        for (int i = 0; i < victim.getInventory().getStorageContents().length; i++) {
+            final ItemStack stack = victim.getInventory().getItem(i);
+            if (stack == null || stack.getType().isAir()) {
+                continue;
+            }
+            for (Material ore : ORE_MATERIALS) {
+                if (stack.getType() == ore) {
+                    ores.add(stack.clone());
+                    victim.getInventory().setItem(i, null);
+                    break;
+                }
+            }
+        }
+
+        final Location dropLocation = victim.getLocation();
+        for (ItemStack stack : ores) {
+            final HashMap<Integer, ItemStack> overflow = killer.getInventory().addItem(stack);
+            for (ItemStack remainder : overflow.values()) {
+                if (remainder != null && !remainder.getType().isAir()) {
+                    dropLocation.getWorld().dropItemNaturally(dropLocation, remainder);
+                }
+            }
         }
     }
 }

--- a/src/main/java/com/kartersanamo/bedwars/listeners/HungerListener.java
+++ b/src/main/java/com/kartersanamo/bedwars/listeners/HungerListener.java
@@ -1,4 +1,34 @@
 package com.kartersanamo.bedwars.listeners;
 
-public class HungerListener {
+import com.kartersanamo.bedwars.Bedwars;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.FoodLevelChangeEvent;
+
+/**
+ * Prevents players from losing hunger while in a Bedwars arena.
+ */
+public final class HungerListener implements Listener {
+
+    private final Bedwars plugin;
+
+    public HungerListener(final Bedwars plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
+    public void onFoodLevelChange(final FoodLevelChangeEvent event) {
+        if (!(event.getEntity() instanceof Player player)) {
+            return;
+        }
+        if (plugin.getArenaManager().getArena(player) == null) {
+            return;
+        }
+        // Prevent any hunger loss (new level would be less than current)
+        if (event.getFoodLevel() < player.getFoodLevel()) {
+            event.setCancelled(true);
+        }
+    }
 }

--- a/src/main/java/com/kartersanamo/bedwars/listeners/MoveListener.java
+++ b/src/main/java/com/kartersanamo/bedwars/listeners/MoveListener.java
@@ -1,7 +1,10 @@
 package com.kartersanamo.bedwars.listeners;
 
 import com.kartersanamo.bedwars.Bedwars;
+import com.kartersanamo.bedwars.api.arena.EGameState;
 import com.kartersanamo.bedwars.api.arena.IArena;
+import com.kartersanamo.bedwars.arena.Arena;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -26,10 +29,22 @@ public final class MoveListener implements Listener {
             return;
         }
 
+        if (arena.getGameState() != EGameState.IN_GAME && arena.getGameState() != EGameState.ENDING) {
+            return;
+        }
+        if (arena instanceof Arena concreteArena) {
+            concreteArena.checkTrapTrigger(player);
+        }
         final int voidY = plugin.getMainConfig().getVoidY();
         if (player.getLocation().getY() < voidY) {
-            // Trigger a standard death; the DeathListener will take over.
-            player.setHealth(0.0D);
+            final String voidMessage = ChatColor.RED + player.getName() + ChatColor.GRAY + " fell into the void.";
+            for (Player p : arena.getPlayers()) {
+                p.sendMessage(voidMessage);
+            }
+            for (Player p : arena.getSpectators()) {
+                p.sendMessage(voidMessage);
+            }
+            DeathListener.handleArenaDeath(plugin, player, null, arena);
         }
     }
 }

--- a/src/main/java/com/kartersanamo/bedwars/listeners/SwordAndArmorEnforcementListener.java
+++ b/src/main/java/com/kartersanamo/bedwars/listeners/SwordAndArmorEnforcementListener.java
@@ -8,6 +8,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -63,9 +64,6 @@ public final class SwordAndArmorEnforcementListener implements Listener {
         final ItemStack dropped = event.getItemDrop().getItemStack();
         if (isPermanentArmor(dropped)) {
             event.setCancelled(true);
-            if (arena instanceof com.kartersanamo.bedwars.arena.Arena a) {
-                a.reapplyArmorIfNeeded(player);
-            }
             return;
         }
         if (isSword(dropped.getType())) {
@@ -86,13 +84,12 @@ public final class SwordAndArmorEnforcementListener implements Listener {
             return;
         }
 
-        // Don't interfere with shop
+        // Don't interfere with shop or upgrades GUI
         final String title = event.getView().getTitle();
-        if (title != null && title.startsWith("Item Shop")) return;
+        if (title != null && (title.startsWith("Item Shop") || title.startsWith("Upgrades & Traps"))) return;
 
         final int rawSlot = event.getRawSlot();
         final Inventory top = event.getView().getTopInventory();
-        final Inventory bottom = event.getView().getBottomInventory();
         final ItemStack current = event.getCurrentItem();
         final ItemStack cursor = event.getCursor();
 
@@ -103,24 +100,14 @@ public final class SwordAndArmorEnforcementListener implements Listener {
         final int playerSlot = clickInPlayerInv ? rawSlot - sizeTop : -1;
         final boolean isArmorSlot = playerSlot >= 36 && playerSlot <= 39;
 
-        // Prevent taking permanent armor out of armor slots (moving to hotbar/main or to top inventory)
+        // Prevent any move that would take permanent armor off (cancel only; never reapply to avoid duplication)
         if (current != null && isPermanentArmor(current) && (isArmorSlot || isArmorSlotOf(current, player.getInventory()))) {
-            // They're trying to move armor out of its slot
-            if (clickInPlayerInv && isArmorSlot) {
-                event.setCancelled(true);
-                if (arena instanceof com.kartersanamo.bedwars.arena.Arena a) {
-                    a.reapplyArmorIfNeeded(player);
-                }
-                return;
-            }
-            // Cursor has armor and they're putting it somewhere else (e.g. chest)
-            if (cursor != null && isPermanentArmor(cursor)) {
-                event.setCancelled(true);
-                if (arena instanceof com.kartersanamo.bedwars.arena.Arena a) {
-                    a.reapplyArmorIfNeeded(player);
-                }
-                return;
-            }
+            event.setCancelled(true);
+            return;
+        }
+        if (cursor != null && isPermanentArmor(cursor) && (!clickInPlayerInv || playerSlot < 36 || playerSlot > 39)) {
+            event.setCancelled(true);
+            return;
         }
 
         // Prevent putting last sword or armor into top inventory (chest, barrel, etc.)
@@ -137,8 +124,32 @@ public final class SwordAndArmorEnforcementListener implements Listener {
             }
             if (moved != null && isPermanentArmor(moved)) {
                 event.setCancelled(true);
-                if (arena instanceof com.kartersanamo.bedwars.arena.Arena a) {
-                    a.reapplyArmorIfNeeded(player);
+            }
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
+    public void onInventoryDrag(final InventoryDragEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) return;
+        final IArena arena = plugin.getArenaManager().getArena(player);
+        if (arena == null) return;
+        if (arena.getGameState() != com.kartersanamo.bedwars.api.arena.EGameState.IN_GAME
+                && arena.getGameState() != com.kartersanamo.bedwars.api.arena.EGameState.ENDING) {
+            return;
+        }
+        final String title = event.getView().getTitle();
+        if (title != null && (title.startsWith("Item Shop") || title.startsWith("Upgrades & Traps"))) return;
+
+        final int sizeTop = event.getView().getTopInventory().getSize();
+        final ItemStack dragged = event.getOldCursor();
+        if (dragged == null || !isPermanentArmor(dragged)) return;
+
+        for (int rawSlot : event.getRawSlots()) {
+            if (rawSlot >= sizeTop) {
+                final int playerSlot = rawSlot - sizeTop;
+                if (playerSlot >= 36 && playerSlot <= 39) {
+                    event.setCancelled(true);
+                    return;
                 }
             }
         }

--- a/src/main/java/com/kartersanamo/bedwars/maprestore/InternalAdapter.java
+++ b/src/main/java/com/kartersanamo/bedwars/maprestore/InternalAdapter.java
@@ -6,12 +6,13 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -84,17 +85,22 @@ public final class InternalAdapter {
 
     /**
      * Restores all modified blocks in the arena region back to their snapshot state.
+     * Also removes all dropped items (Item entities) within the snapshot region.
      */
     public void restoreArena(final IArena arena) {
         final Map<BlockPosition, BlockData> snapshot = arenaSnapshots.get(arena.getId());
         final Set<BlockPosition> modified = modifiedBlocks.get(arena.getId());
 
-        if (snapshot == null || modified == null || snapshot.isEmpty() || modified.isEmpty()) {
+        final World world = arena.getWorld();
+        if (world == null) {
             return;
         }
 
-        final World world = arena.getWorld();
-        if (world == null) {
+        if (snapshot != null && !snapshot.isEmpty()) {
+            clearDroppedItemsInSnapshotBounds(world, snapshot.keySet());
+        }
+
+        if (snapshot == null || modified == null || modified.isEmpty()) {
             return;
         }
 
@@ -108,6 +114,31 @@ public final class InternalAdapter {
         }
 
         modified.clear();
+    }
+
+    private void clearDroppedItemsInSnapshotBounds(final World world, final Set<BlockPosition> positions) {
+        int minX = Integer.MAX_VALUE, minY = Integer.MAX_VALUE, minZ = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE, maxY = Integer.MIN_VALUE, maxZ = Integer.MIN_VALUE;
+        for (BlockPosition p : positions) {
+            minX = Math.min(minX, p.x());
+            minY = Math.min(minY, p.y());
+            minZ = Math.min(minZ, p.z());
+            maxX = Math.max(maxX, p.x());
+            maxY = Math.max(maxY, p.y());
+            maxZ = Math.max(maxZ, p.z());
+        }
+        for (Entity entity : world.getEntities()) {
+            if (!(entity instanceof Item)) {
+                continue;
+            }
+            final Location loc = entity.getLocation();
+            final int bx = loc.getBlockX();
+            final int by = loc.getBlockY();
+            final int bz = loc.getBlockZ();
+            if (bx >= minX && bx <= maxX && by >= minY && by <= maxY && bz >= minZ && bz <= maxZ) {
+                entity.remove();
+            }
+        }
     }
 
     private static Location min(final Location a, final Location b) {

--- a/src/main/java/com/kartersanamo/bedwars/shop/ShopInventoryHolder.java
+++ b/src/main/java/com/kartersanamo/bedwars/shop/ShopInventoryHolder.java
@@ -1,0 +1,29 @@
+package com.kartersanamo.bedwars.shop;
+
+import com.kartersanamo.bedwars.api.arena.shop.IContentTier;
+import com.kartersanamo.bedwars.shop.main.ShopCategory;
+import org.bukkit.inventory.InventoryHolder;
+
+import java.util.List;
+
+/**
+ * Holder for the 54-slot shop GUI. Tracks current view and which tiers are in content slots (9–53).
+ */
+public interface ShopInventoryHolder extends InventoryHolder {
+
+    /** View id: "quick_buy" or category id (blocks, melee, armor, etc.). */
+    String getViewId();
+
+    /** Category when viewing a category; null when viewing Quick Buy. */
+    ShopCategory getCategory();
+
+    /** Tiers in order for content slots 9–53. Index 0 = slot 9. */
+    List<IContentTier> getContentTiers();
+
+    /** Tier at content slot index (0-based). Content slot = 9 + index. */
+    default IContentTier getTierAtContentIndex(int index) {
+        List<IContentTier> tiers = getContentTiers();
+        if (index < 0 || index >= tiers.size()) return null;
+        return tiers.get(index);
+    }
+}

--- a/src/main/java/com/kartersanamo/bedwars/shop/ShopInventoryHolderImpl.java
+++ b/src/main/java/com/kartersanamo/bedwars/shop/ShopInventoryHolderImpl.java
@@ -1,0 +1,35 @@
+package com.kartersanamo.bedwars.shop;
+
+import com.kartersanamo.bedwars.api.arena.shop.IContentTier;
+import com.kartersanamo.bedwars.shop.main.ShopCategory;
+
+import java.util.Collections;
+import java.util.List;
+
+final class ShopInventoryHolderImpl implements ShopInventoryHolder {
+
+    private final String viewId;
+    private final ShopCategory category;
+    private final List<IContentTier> contentTiers;
+
+    ShopInventoryHolderImpl(final String viewId, final ShopCategory category, final List<IContentTier> contentTiers) {
+        this.viewId = viewId;
+        this.category = category;
+        this.contentTiers = contentTiers != null ? List.copyOf(contentTiers) : Collections.emptyList();
+    }
+
+    @Override
+    public String getViewId() {
+        return viewId;
+    }
+
+    @Override
+    public ShopCategory getCategory() {
+        return category;
+    }
+
+    @Override
+    public List<IContentTier> getContentTiers() {
+        return contentTiers;
+    }
+}

--- a/src/main/java/com/kartersanamo/bedwars/shop/ShopManager.java
+++ b/src/main/java/com/kartersanamo/bedwars/shop/ShopManager.java
@@ -1,5 +1,6 @@
 package com.kartersanamo.bedwars.shop;
 
+import com.kartersanamo.bedwars.api.arena.IArena;
 import com.kartersanamo.bedwars.api.arena.shop.IContentTier;
 import com.kartersanamo.bedwars.arena.kit.ArmorTier;
 import com.kartersanamo.bedwars.arena.kit.ToolTier;
@@ -7,6 +8,7 @@ import com.kartersanamo.bedwars.shop.main.CategoryContent;
 import com.kartersanamo.bedwars.shop.main.ShopCategory;
 import com.kartersanamo.bedwars.shop.tiers.ShopTiers;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -16,37 +18,56 @@ import org.bukkit.inventory.meta.ItemMeta;
 import java.util.*;
 
 /**
- * Shop manager: categories and slot-to-tier lookup for purchases.
+ * Shop manager: 54-slot GUI with top row categories (Quick Buy, Blocks, Melee, Armor, Tools, Ranged, Potions, Utility, Rotating Items).
  */
 public final class ShopManager {
 
+    private static final int CONTENT_START = 9;
+    private static final int CONTENT_SLOTS = 45;
+
+    /** Nav order: slot 0 = Quick Buy, 1 = Blocks, 2 = Melee, 3 = Armor, 4 = Tools, 5 = Ranged, 6 = Potions, 7 = Utility, 8 = Rotating Items. */
+    private static final String[] NAV_ORDER = {
+            "quick_buy", "blocks", "melee", "armor", "tools", "ranged", "potions", "utility", "rotating"
+    };
+
     private final Map<String, ShopCategory> categories = new LinkedHashMap<>();
+    private final List<IContentTier> defaultQuickBuyTiers = new ArrayList<>();
 
     public ShopManager() {
         loadDefaultShop();
+        buildDefaultQuickBuy();
     }
 
     private void loadDefaultShop() {
         // --- Blocks ---
-        final ShopCategory blocks = new ShopCategory("blocks", namedItem(Material.WHITE_WOOL, "Blocks"));
+        final ShopCategory blocks = new ShopCategory("blocks", navIcon(Material.TERRACOTTA, "Blocks"));
         blocks.addContent(new CategoryContent("wool", List.of(ShopTiers.wool(16, 4))));
-        blocks.addContent(new CategoryContent("ladder", List.of(ShopTiers.item(Material.LADDER, 8, 4, Material.IRON_INGOT))));
+        blocks.addContent(new CategoryContent("terracotta", List.of(ShopTiers.item(Material.TERRACOTTA, 16, 16, Material.IRON_INGOT))));
         blocks.addContent(new CategoryContent("glass", List.of(ShopTiers.item(Material.GLASS, 4, 12, Material.IRON_INGOT))));
-        blocks.addContent(new CategoryContent("clay", List.of(ShopTiers.item(Material.TERRACOTTA, 24, 16, Material.IRON_INGOT))));
-        blocks.addContent(new CategoryContent("endstone", List.of(ShopTiers.item(Material.END_STONE, 12, 24, Material.IRON_INGOT))));
+        blocks.addContent(new CategoryContent("sand", List.of(ShopTiers.item(Material.SAND, 12, 12, Material.IRON_INGOT))));
+        blocks.addContent(new CategoryContent("ladder", List.of(ShopTiers.item(Material.LADDER, 8, 4, Material.IRON_INGOT))));
         blocks.addContent(new CategoryContent("wood", List.of(ShopTiers.item(Material.OAK_PLANKS, 16, 4, Material.GOLD_INGOT))));
         blocks.addContent(new CategoryContent("obsidian", List.of(ShopTiers.item(Material.OBSIDIAN, 4, 4, Material.EMERALD))));
+        blocks.addContent(new CategoryContent("packed_ice", List.of(ShopTiers.item(Material.PACKED_ICE, 8, 8, Material.IRON_INGOT))));
+        blocks.addContent(new CategoryContent("endstone", List.of(ShopTiers.item(Material.END_STONE, 12, 24, Material.IRON_INGOT))));
         categories.put(blocks.getId(), blocks);
 
-        // --- Swords (Melee) ---
-        final ShopCategory swords = new ShopCategory("swords", namedItem(Material.GOLDEN_SWORD, "Swords"));
-        swords.addContent(new CategoryContent("stone_sword", List.of(ShopTiers.sword(Material.STONE_SWORD, 10, Material.IRON_INGOT))));
-        swords.addContent(new CategoryContent("iron_sword", List.of(ShopTiers.sword(Material.IRON_SWORD, 7, Material.GOLD_INGOT))));
-        swords.addContent(new CategoryContent("diamond_sword", List.of(ShopTiers.diamondSword())));
-        categories.put(swords.getId(), swords);
+        // --- Melee ---
+        final ShopCategory melee = new ShopCategory("melee", navIcon(Material.GOLDEN_SWORD, "Melee"));
+        melee.addContent(new CategoryContent("stone_sword", List.of(ShopTiers.sword(Material.STONE_SWORD, 10, Material.IRON_INGOT))));
+        melee.addContent(new CategoryContent("iron_sword", List.of(ShopTiers.sword(Material.IRON_SWORD, 7, Material.GOLD_INGOT))));
+        melee.addContent(new CategoryContent("diamond_sword", List.of(ShopTiers.diamondSword())));
+        categories.put(melee.getId(), melee);
+
+        // --- Armor ---
+        final ShopCategory armor = new ShopCategory("armor", navIcon(Material.LEATHER_BOOTS, "Armor"));
+        armor.addContent(new CategoryContent("chainmail", List.of(ShopTiers.armorUpgrade(ArmorTier.CHAINMAIL, 30, Material.IRON_INGOT))));
+        armor.addContent(new CategoryContent("iron_armor", List.of(ShopTiers.armorUpgrade(ArmorTier.IRON, 12, Material.GOLD_INGOT))));
+        armor.addContent(new CategoryContent("diamond_armor", List.of(ShopTiers.armorUpgrade(ArmorTier.DIAMOND, 6, Material.EMERALD))));
+        categories.put(armor.getId(), armor);
 
         // --- Tools ---
-        final ShopCategory tools = new ShopCategory("tools", namedItem(Material.IRON_PICKAXE, "Tools"));
+        final ShopCategory tools = new ShopCategory("tools", navIcon(Material.WOODEN_PICKAXE, "Tools"));
         tools.addContent(new CategoryContent("axe", List.of(
                 ShopTiers.axeUpgrade(ToolTier.WOOD, 10, Material.IRON_INGOT),
                 ShopTiers.axeUpgrade(ToolTier.STONE, 10, Material.IRON_INGOT),
@@ -62,40 +83,151 @@ public final class ShopManager {
         tools.addContent(new CategoryContent("shears", List.of(ShopTiers.shears(20))));
         categories.put(tools.getId(), tools);
 
-        // --- Armor ---
-        final ShopCategory armor = new ShopCategory("armor", namedItem(Material.LEATHER_CHESTPLATE, "Armor"));
-        armor.addContent(new CategoryContent("chainmail", List.of(ShopTiers.armorUpgrade(ArmorTier.CHAINMAIL, 30, Material.IRON_INGOT))));
-        armor.addContent(new CategoryContent("iron_armor", List.of(ShopTiers.armorUpgrade(ArmorTier.IRON, 12, Material.GOLD_INGOT))));
-        armor.addContent(new CategoryContent("diamond_armor", List.of(ShopTiers.armorUpgrade(ArmorTier.DIAMOND, 6, Material.EMERALD))));
-        categories.put(armor.getId(), armor);
-
-        // --- Ranged (Bow) ---
-        final ShopCategory ranged = new ShopCategory("ranged", namedItem(Material.BOW, "Ranged"));
+        // --- Ranged ---
+        final ShopCategory ranged = new ShopCategory("ranged", navIcon(Material.BOW, "Ranged"));
         ranged.addContent(new CategoryContent("arrows", List.of(ShopTiers.item(Material.ARROW, 6, 2, Material.GOLD_INGOT))));
         ranged.addContent(new CategoryContent("bow", List.of(ShopTiers.item(Material.BOW, 12, Material.GOLD_INGOT))));
         ranged.addContent(new CategoryContent("power_bow", List.of(ShopTiers.powerBow())));
         ranged.addContent(new CategoryContent("punch_bow", List.of(ShopTiers.punchBow())));
         categories.put(ranged.getId(), ranged);
 
-        // --- Weapons (Knockback Stick) ---
-        final ShopCategory weapons = new ShopCategory("weapons", namedItem(Material.STICK, "Weapons"));
-        weapons.addContent(new CategoryContent("kb_stick", List.of(ShopTiers.knockbackStick())));
-        categories.put(weapons.getId(), weapons);
+        // --- Potions (empty for now / seasonal) ---
+        final ShopCategory potions = new ShopCategory("potions", navIcon(Material.POTION, "Potions"));
+        categories.put(potions.getId(), potions);
 
         // --- Utility ---
-        final ShopCategory utility = new ShopCategory("utility", namedItem(Material.GOLDEN_APPLE, "Utility"));
+        final ShopCategory utility = new ShopCategory("utility", navIcon(Material.TNT, "Utility"));
         utility.addContent(new CategoryContent("gapple", List.of(ShopTiers.goldenApple())));
         utility.addContent(new CategoryContent("ender_pearl", List.of(ShopTiers.enderPearl())));
+        utility.addContent(new CategoryContent("kb_stick", List.of(ShopTiers.knockbackStick())));
+        utility.addContent(new CategoryContent("water_bucket", List.of(ShopTiers.item(Material.WATER_BUCKET, 1, 1, Material.EMERALD))));
         categories.put(utility.getId(), utility);
+
+        // --- Rotating Items (empty for now / seasonal) ---
+        final ShopCategory rotating = new ShopCategory("rotating", navIcon(Material.GRAY_STAINED_GLASS_PANE, "Rotating Items"));
+        categories.put(rotating.getId(), rotating);
     }
 
-    public void openShop(final Player player) {
-        final Inventory inventory = Bukkit.createInventory(player, 27, "Item Shop");
-        int slot = 0;
-        for (ShopCategory category : categories.values()) {
-            inventory.setItem(slot++, category.getIcon());
+    private void buildDefaultQuickBuy() {
+        defaultQuickBuyTiers.clear();
+        final ShopCategory blocks = getCategory("blocks");
+        final ShopCategory melee = getCategory("melee");
+        final ShopCategory armor = getCategory("armor");
+        final ShopCategory tools = getCategory("tools");
+        final ShopCategory ranged = getCategory("ranged");
+        final ShopCategory utility = getCategory("utility");
+        collectFirstTier(blocks, defaultQuickBuyTiers, 1);
+        defaultQuickBuyTiers.add(getTierAtSlot(melee, 0));
+        defaultQuickBuyTiers.add(getTierAtSlot(armor, 0));
+        defaultQuickBuyTiers.add(getTierAtSlot(tools, 0));
+        defaultQuickBuyTiers.add(getTierAtSlot(ranged, 0));
+        defaultQuickBuyTiers.add(getTierAtSlot(utility, 0));
+        defaultQuickBuyTiers.add(getTierAtSlot(utility, 1));
+        defaultQuickBuyTiers.add(getTierAtSlot(utility, 2));
+        defaultQuickBuyTiers.add(getTierAtSlot(utility, 3));
+        defaultQuickBuyTiers.removeIf(Objects::isNull);
+    }
+
+    private static void collectFirstTier(final ShopCategory category, final List<IContentTier> out, final int maxPerContent) {
+        if (category == null) return;
+        for (CategoryContent content : category.getContents()) {
+            int n = 0;
+            for (IContentTier tier : content.getTiers()) {
+                if (n++ >= maxPerContent) break;
+                out.add(tier);
+            }
         }
-        player.openInventory(inventory);
+    }
+
+    /** Opens the shop; default view is Quick Buy. */
+    public void openShop(final Player player, final IArena arena) {
+        openView(player, "quick_buy", arena);
+    }
+
+    /** Opens a specific view (quick_buy or category id). */
+    public void openView(final Player player, final String viewId, final IArena arena) {
+        final String title = viewTitle(viewId);
+        final ShopCategory category = "quick_buy".equals(viewId) ? null : getCategory(viewId);
+        final List<IContentTier> contentTiers = "quick_buy".equals(viewId)
+                ? defaultQuickBuyTiers
+                : getContentTiersList(category);
+        final ShopInventoryHolder holder = new ShopInventoryHolderImpl(viewId, category, contentTiers);
+        final Inventory inv = Bukkit.createInventory(holder, 54, title);
+
+        for (int i = 0; i < NAV_ORDER.length; i++) {
+            inv.setItem(i, navItemForSlot(i));
+        }
+        for (int i = 0; i < contentTiers.size() && i < CONTENT_SLOTS; i++) {
+            inv.setItem(CONTENT_START + i, displayItem(contentTiers.get(i), arena));
+        }
+        player.openInventory(inv);
+    }
+
+    private static String viewTitle(final String viewId) {
+        if ("quick_buy".equals(viewId)) return "Quick Buy";
+        return switch (viewId) {
+            case "blocks" -> "Blocks";
+            case "melee" -> "Melee";
+            case "armor" -> "Armor";
+            case "tools" -> "Tools";
+            case "ranged" -> "Ranged";
+            case "potions" -> "Potions";
+            case "utility" -> "Utility";
+            case "rotating" -> "Rotating Items";
+            default -> viewId;
+        };
+    }
+
+    private ItemStack navItemForSlot(final int slot) {
+        if (slot == 0) {
+            return navIcon(Material.NETHER_STAR, "Quick Buy");
+        }
+        final String id = NAV_ORDER[slot];
+        final ShopCategory cat = getCategory(id);
+        if (cat == null) return navIcon(Material.GRAY_STAINED_GLASS_PANE, viewTitle(id));
+        final ItemStack icon = cat.getIcon().clone();
+        final ItemMeta meta = icon.getItemMeta();
+        if (meta != null) {
+            meta.setLore(List.of(ChatColor.YELLOW + "Click to view!"));
+            icon.setItemMeta(meta);
+        }
+        return icon;
+    }
+
+    private ItemStack displayItem(final IContentTier tier, final IArena arena) {
+        final ItemStack item = tier.getItem().clone();
+        final ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            final int cost = tier.getCostFor(arena);
+            final String currencyName = formatCurrency(tier.getCurrency());
+            final List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.WHITE + "Cost: " + cost + " " + currencyName);
+            lore.add(ChatColor.AQUA + "Shift Click to add to Quick Buy");
+            meta.setLore(lore);
+            if (meta.hasDisplayName()) {
+                meta.setDisplayName(ChatColor.RED + ChatColor.stripColor(meta.getDisplayName()));
+            }
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private static String formatCurrency(final Material m) {
+        if (m == Material.IRON_INGOT) return "Iron";
+        if (m == Material.GOLD_INGOT) return "Gold";
+        if (m == Material.DIAMOND) return "Diamond";
+        if (m == Material.EMERALD) return "Emerald";
+        final String n = m.name().toLowerCase().replace("_", " ");
+        return n.isEmpty() ? n : Character.toUpperCase(n.charAt(0)) + n.substring(1);
+    }
+
+    private List<IContentTier> getContentTiersList(final ShopCategory category) {
+        if (category == null) return Collections.emptyList();
+        final List<IContentTier> list = new ArrayList<>();
+        for (CategoryContent content : category.getContents()) {
+            list.addAll(content.getTiers());
+        }
+        return list;
     }
 
     public Collection<ShopCategory> getCategories() {
@@ -106,9 +238,11 @@ public final class ShopManager {
         return categories.get(id != null ? id.toLowerCase() : null);
     }
 
-    /**
-     * Returns the tier at the given slot when viewing the given category (same order as openCategory).
-     */
+    public String[] getNavOrder() {
+        return NAV_ORDER.clone();
+    }
+
+    /** Returns the tier at content slot index (0-based) for the given category. */
     public IContentTier getTierAtSlot(final ShopCategory category, final int slot) {
         if (category == null || slot < 0) return null;
         int index = 0;
@@ -121,23 +255,11 @@ public final class ShopManager {
         return null;
     }
 
-    public void openCategory(final Player player, final ShopCategory category) {
-        final String title = "Item Shop - " + category.getId();
-        final Inventory inventory = Bukkit.createInventory(player, 54, title);
-        int slot = 0;
-        for (CategoryContent content : category.getContents()) {
-            for (IContentTier tier : content.getTiers()) {
-                if (slot < 54) inventory.setItem(slot++, tier.getItem());
-            }
-        }
-        player.openInventory(inventory);
-    }
-
-    private ItemStack namedItem(final Material material, final String name) {
+    private static ItemStack navIcon(final Material material, final String name) {
         final ItemStack stack = new ItemStack(material);
         final ItemMeta meta = stack.getItemMeta();
         if (meta != null) {
-            meta.setDisplayName(name);
+            meta.setDisplayName(ChatColor.GREEN + name);
             stack.setItemMeta(meta);
         }
         return stack;

--- a/src/main/java/com/kartersanamo/bedwars/shop/listeners/ShopInventoryListener.java
+++ b/src/main/java/com/kartersanamo/bedwars/shop/listeners/ShopInventoryListener.java
@@ -2,9 +2,10 @@ package com.kartersanamo.bedwars.shop.listeners;
 
 import com.kartersanamo.bedwars.Bedwars;
 import com.kartersanamo.bedwars.api.arena.IArena;
+import com.kartersanamo.bedwars.arena.Arena;
 import com.kartersanamo.bedwars.api.arena.shop.IContentTier;
+import com.kartersanamo.bedwars.shop.ShopInventoryHolder;
 import com.kartersanamo.bedwars.shop.ShopManager;
-import com.kartersanamo.bedwars.shop.main.ShopCategory;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -15,12 +16,12 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 /**
- * Handles interactions within the Bedwars shop inventories.
+ * Handles interactions in the 54-slot shop GUI: category row (0–8) switches view,
+ * content slots (9–53) purchase or add to Quick Buy.
  */
 public final class ShopInventoryListener implements Listener {
 
-    private static final String ROOT_TITLE = "Item Shop";
-    private static final String CATEGORY_TITLE_PREFIX = ROOT_TITLE + " - ";
+    private static final int CONTENT_START = 9;
 
     private final Bedwars plugin;
     private final ShopManager shopManager;
@@ -36,47 +37,46 @@ public final class ShopInventoryListener implements Listener {
             return;
         }
 
-        final String title = event.getView().getTitle();
-        if (!title.startsWith(ROOT_TITLE)) {
-            return;
-        }
-
-        final ItemStack clicked = event.getCurrentItem();
-        if (clicked == null || clicked.getType() == Material.AIR) {
+        if (!(event.getInventory().getHolder() instanceof ShopInventoryHolder holder)) {
             return;
         }
 
         event.setCancelled(true);
 
-        if (ROOT_TITLE.equals(title)) {
-            handleRootClick(player, clicked);
-        } else if (title.startsWith(CATEGORY_TITLE_PREFIX)) {
-            final String categoryId = ChatColor.stripColor(title.substring(CATEGORY_TITLE_PREFIX.length())).trim().toLowerCase();
-            final int slot = event.getRawSlot();
-            final Inventory top = event.getView().getTopInventory();
-            if (slot >= 0 && slot < top.getSize()) {
-                final ShopCategory category = shopManager.getCategory(categoryId);
-                handleCategoryClick(player, category, slot);
-            }
+        final int rawSlot = event.getRawSlot();
+        final Inventory top = event.getView().getTopInventory();
+        if (rawSlot < 0 || rawSlot >= top.getSize()) {
+            return;
         }
-    }
 
-    private void handleRootClick(final Player player, final ItemStack clicked) {
-        for (ShopCategory category : shopManager.getCategories()) {
-            if (category.getIcon().isSimilar(clicked)) {
-                shopManager.openCategory(player, category);
-                return;
-            }
+        if (rawSlot < CONTENT_START) {
+            handleCategoryRowClick(player, rawSlot);
+            return;
         }
-    }
 
-    private void handleCategoryClick(final Player player, final ShopCategory category, final int slot) {
-        if (category == null) return;
-
-        final IContentTier tier = shopManager.getTierAtSlot(category, slot);
-        if (tier == null) return;
+        final int contentIndex = rawSlot - CONTENT_START;
+        final IContentTier tier = holder.getTierAtContentIndex(contentIndex);
+        if (tier == null) {
+            return;
+        }
 
         final IArena arena = plugin.getArenaManager().getArena(player);
+        if (event.isShiftClick()) {
+            // TODO: add to Quick Buy
+        } else {
+            tryPurchase(player, tier, arena);
+        }
+    }
+
+    private void handleCategoryRowClick(final Player player, final int navSlot) {
+        final String[] navOrder = shopManager.getNavOrder();
+        if (navSlot < 0 || navSlot >= navOrder.length) return;
+        final String viewId = navOrder[navSlot];
+        final IArena arena = plugin.getArenaManager().getArena(player);
+        shopManager.openView(player, viewId, arena);
+    }
+
+    private void tryPurchase(final Player player, final IContentTier tier, final IArena arena) {
         final int cost = tier.getCostFor(arena);
         final Material currency = tier.getCurrency();
 
@@ -88,7 +88,8 @@ public final class ShopInventoryListener implements Listener {
         }
 
         if (total < cost) {
-            player.sendMessage(ChatColor.RED + "You don't have enough " + formatCurrency(currency) + " (need " + cost + ").");
+            final int needMore = cost - total;
+            player.sendMessage(ChatColor.RED + "You don't have enough " + formatCurrencyDisplay(currency) + "! Need " + needMore + " more!");
             return;
         }
         if (!tier.canPurchase(player, arena)) {
@@ -111,7 +112,38 @@ public final class ShopInventoryListener implements Listener {
         }
 
         tier.giveReward(player, arena);
-        player.sendMessage(ChatColor.GREEN + "Purchased!");
+        if (arena instanceof Arena concreteArena) {
+            concreteArena.applyTeamUpgradesToInventory(player);
+        }
+        final String itemName = formatItemName(tier.getItem());
+        player.sendMessage(ChatColor.GREEN + "You purchased " + ChatColor.GOLD + itemName);
+    }
+
+    private static String formatItemName(final ItemStack item) {
+        if (item != null && item.hasItemMeta() && item.getItemMeta().hasDisplayName()) {
+            return ChatColor.stripColor(item.getItemMeta().getDisplayName());
+        }
+        if (item != null && item.getType() != Material.AIR) {
+            final String[] words = item.getType().name().toLowerCase().split("_");
+            final StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < words.length; i++) {
+                if (i > 0) sb.append(" ");
+                if (!words[i].isEmpty()) {
+                    sb.append(Character.toUpperCase(words[i].charAt(0))).append(words[i].substring(1));
+                }
+            }
+            return sb.toString();
+        }
+        return "Item";
+    }
+
+    private static String formatCurrencyDisplay(final Material m) {
+        if (m == Material.IRON_INGOT) return "Iron";
+        if (m == Material.GOLD_INGOT) return "Gold";
+        if (m == Material.DIAMOND) return "Diamond";
+        if (m == Material.EMERALD) return "Emerald";
+        final String n = m.name().toLowerCase().replace("_", " ");
+        return n.isEmpty() ? n : Character.toUpperCase(n.charAt(0)) + n.substring(1);
     }
 
     private static String formatCurrency(final Material m) {

--- a/src/main/java/com/kartersanamo/bedwars/shop/listeners/ShopOpenListener.java
+++ b/src/main/java/com/kartersanamo/bedwars/shop/listeners/ShopOpenListener.java
@@ -1,23 +1,33 @@
 package com.kartersanamo.bedwars.shop.listeners;
 
+import com.kartersanamo.bedwars.Bedwars;
+import com.kartersanamo.bedwars.arena.Arena;
 import com.kartersanamo.bedwars.shop.ShopManager;
+import com.kartersanamo.bedwars.upgrades.UpgradeManager;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 
 /**
- * Opens the shop when a player interacts with a shop NPC or villager.
- *
- * For the MVP we keep this simple and open the shop when interacting with
- * any villager; later this can be restricted via configuration.
+ * Opens the shop or upgrades GUI when a player right-clicks a villager NPC.
  */
 public final class ShopOpenListener implements Listener {
 
     private final ShopManager shopManager;
+    private final UpgradeManager upgradeManager;
+    private final Bedwars plugin;
 
     public ShopOpenListener(final ShopManager shopManager) {
         this.shopManager = shopManager;
+        this.upgradeManager = null;
+        this.plugin = null;
+    }
+
+    public ShopOpenListener(final Bedwars plugin, final ShopManager shopManager, final UpgradeManager upgradeManager) {
+        this.shopManager = shopManager;
+        this.upgradeManager = upgradeManager;
+        this.plugin = plugin;
     }
 
     @EventHandler(ignoreCancelled = true)
@@ -27,7 +37,20 @@ public final class ShopOpenListener implements Listener {
         }
 
         final Player player = event.getPlayer();
-        shopManager.openShop(player);
+        final var arena = plugin != null ? plugin.getArenaManager().getArena(player) : null;
+        if (arena == null) {
+            event.setCancelled(true);
+            return;
+        }
+
+        final String name = event.getRightClicked().getCustomName();
+        if (name != null && name.contains("Upgrades") && upgradeManager != null && arena instanceof Arena concreteArena) {
+            arena.getTeam(player).ifPresent(team -> upgradeManager.openGui(player, concreteArena, team));
+            event.setCancelled(true);
+            return;
+        }
+
+        shopManager.openShop(player, arena);
         event.setCancelled(true);
     }
 }

--- a/src/main/java/com/kartersanamo/bedwars/shop/tiers/ShopTiers.java
+++ b/src/main/java/com/kartersanamo/bedwars/shop/tiers/ShopTiers.java
@@ -9,6 +9,7 @@ import com.kartersanamo.bedwars.arena.kit.ToolTier;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -48,7 +49,7 @@ public final class ShopTiers {
     }
 
     public static IContentTier sword(final Material swordType, final int cost, final Material currency) {
-        return new ItemTier(unbreakable(new ItemStack(swordType)), cost, currency);
+        return new SwordUpgradeTier(swordType, cost, currency);
     }
 
     public static IContentTier bow(final ItemStack bow, final int cost, final Material currency) {
@@ -350,7 +351,62 @@ public final class ShopTiers {
 
         @Override
         public void giveReward(final Player player, final IArena arena) {
-            player.getInventory().addItem(unbreakable(new ItemStack(Material.DIAMOND_SWORD)));
+            replaceFirstSwordWith(player.getInventory(), unbreakable(new ItemStack(Material.DIAMOND_SWORD)));
+        }
+    }
+
+    private static final Material[] SWORD_MATERIALS = {
+            Material.WOODEN_SWORD, Material.STONE_SWORD, Material.GOLDEN_SWORD, Material.IRON_SWORD, Material.DIAMOND_SWORD
+    };
+
+    private static boolean isSword(final Material type) {
+        for (Material m : SWORD_MATERIALS) {
+            if (m == type) return true;
+        }
+        return false;
+    }
+
+    /** Replaces the first sword in the inventory with the new sword; if none found, adds the item. */
+    private static void replaceFirstSwordWith(final Inventory inv, final ItemStack newSword) {
+        for (int i = 0; i < inv.getSize(); i++) {
+            final ItemStack stack = inv.getItem(i);
+            if (stack != null && !stack.getType().isAir() && isSword(stack.getType())) {
+                inv.setItem(i, newSword);
+                return;
+            }
+        }
+        inv.addItem(newSword);
+    }
+
+    private static final class SwordUpgradeTier implements IContentTier {
+        private final ItemStack reward;
+        private final int cost;
+        private final Material currency;
+
+        SwordUpgradeTier(final Material swordType, final int cost, final Material currency) {
+            this.reward = unbreakable(new ItemStack(swordType));
+            this.cost = cost;
+            this.currency = currency;
+        }
+
+        @Override
+        public ItemStack getItem() {
+            return reward.clone();
+        }
+
+        @Override
+        public int getCost() {
+            return cost;
+        }
+
+        @Override
+        public Material getCurrency() {
+            return currency;
+        }
+
+        @Override
+        public void giveReward(final Player player, final IArena arena) {
+            replaceFirstSwordWith(player.getInventory(), reward.clone());
         }
     }
 }

--- a/src/main/java/com/kartersanamo/bedwars/sidebar/SidebarService.java
+++ b/src/main/java/com/kartersanamo/bedwars/sidebar/SidebarService.java
@@ -1,10 +1,13 @@
 package com.kartersanamo.bedwars.sidebar;
 
+import com.kartersanamo.bedwars.Bedwars;
+import com.kartersanamo.bedwars.api.arena.EGameState;
 import com.kartersanamo.bedwars.api.arena.IArena;
 import com.kartersanamo.bedwars.api.arena.team.ETeamColor;
 import com.kartersanamo.bedwars.api.arena.team.ITeam;
 import com.kartersanamo.bedwars.api.sidebar.ISidebar;
 import com.kartersanamo.bedwars.api.sidebar.ISidebarManager;
+import com.kartersanamo.bedwars.database.PlayerStats;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
@@ -12,11 +15,17 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 /**
- * Simple sidebar manager that shows arena state and team bed status.
+ * Sidebar manager: waiting-lobby scoreboard (map, players, status, mode, version)
+ * and in-game scoreboard (team bed status).
  */
 public final class SidebarService implements ISidebarManager {
 
     private final Map<UUID, ISidebar> sidebars = new HashMap<>();
+    private final Bedwars plugin;
+
+    public SidebarService(final Bedwars plugin) {
+        this.plugin = plugin;
+    }
 
     @Override
     public ISidebar createSidebar(final Player player) {
@@ -34,62 +43,18 @@ public final class SidebarService implements ISidebarManager {
         if (sidebar != null) {
             sidebar.remove();
         }
+        player.setPlayerListHeaderFooter("", "");
     }
 
     public void updateForArena(final IArena arena) {
         final String title = ChatColor.YELLOW.toString() + ChatColor.BOLD + "BED WARS";
-
-        final List<String> lines = new ArrayList<>();
-
-        // Top date line similar to Hypixel style.
-        final String date = new SimpleDateFormat("MM/dd/yy").format(new Date());
-        lines.add(ChatColor.GRAY + date);
-
-        lines.add(" ");
-
-        // Placeholder for future NextEvent implementation.
-        lines.add(ChatColor.WHITE + "Bed gone in " + ChatColor.GREEN + "3:51");
-
-        lines.add(" ");
-
-        // Team lines in canonical color order to mirror Hypixel.
-        final List<ITeam> arenaTeams = arena.getTeams();
-        for (ETeamColor color : ETeamColor.values()) {
-            final Optional<ITeam> maybeTeam = arenaTeams.stream()
-                    .filter(team -> team.getColor() == color)
-                    .findFirst();
-
-            final String colorDisplayName = capitalize(color.name().toLowerCase(Locale.ROOT));
-            final String prefixLetter = color.name().substring(0, 1);
-
-            String status;
-            if (maybeTeam.isEmpty()) {
-                status = ChatColor.RED + "✖";
-            } else {
-                final ITeam team = maybeTeam.get();
-                if (!team.isBedDestroyed()) {
-                    status = ChatColor.GREEN + "✔";
-                } else {
-                    // Bed destroyed: show number of alive players remaining, or X if none.
-                    final long alive = team.getOnlineMembers().stream()
-                            .filter(p -> arena.contains(p) && !p.isDead())
-                            .count();
-                    if (alive > 0) {
-                        status = ChatColor.YELLOW.toString() + alive;
-                    } else {
-                        status = ChatColor.RED + "✖";
-                    }
-                }
-            }
-
-            final String line = color.getChatColor() + prefixLetter + " "
-                    + color.getChatColor() + colorDisplayName + ChatColor.WHITE + ": "
-                    + status;
-            lines.add(line);
+        final List<String> lines;
+        final EGameState state = arena.getGameState();
+        if (state == EGameState.LOBBY_WAITING || state == EGameState.STARTING) {
+            lines = buildLobbyLines(arena);
+        } else {
+            lines = buildGameLines(arena);
         }
-
-        lines.add(" ");
-        lines.add(ChatColor.GOLD + "play.kartersanamo.com");
 
         for (Player player : arena.getPlayers()) {
             if (!player.getWorld().equals(arena.getWorld())) {
@@ -99,13 +64,108 @@ public final class SidebarService implements ISidebarManager {
             final ISidebar sidebar = createSidebar(player);
             sidebar.setTitle(title);
             sidebar.setLines(lines);
+            updateTabList(player);
         }
     }
 
-    private String capitalize(final String input) {
-        if (input == null || input.isEmpty()) {
-            return input;
+    /**
+     * Sets the tab list header and footer for a player in an arena.
+     * Header: "You are playing on PLAY.KARTERSANAMO.COM"
+     * Footer: "Kills: X Final Kills: Y Beds Broken: Z" and "Ranks, Boosters & MORE! STORE.KARTERSANAMO.COM"
+     */
+    private void updateTabList(final Player player) {
+        final String header = ChatColor.AQUA + "You are playing on " + ChatColor.YELLOW + ChatColor.BOLD + "PLAY.KARTERSANAMO.COM";
+        int kills = 0, finalKills = 0, bedsBroken = 0;
+        try {
+            final PlayerStats stats = plugin.getDatabase().getCachedStats(player.getUniqueId(), player.getName());
+            kills = stats.getKills();
+            finalKills = stats.getFinalKills();
+            bedsBroken = stats.getBedsBroken();
+        } catch (Exception ignored) {
         }
+        final String footer = ChatColor.GRAY + "Kills: " + ChatColor.WHITE + kills
+                + ChatColor.GRAY + " Final Kills: " + ChatColor.WHITE + finalKills
+                + ChatColor.GRAY + " Beds Broken: " + ChatColor.WHITE + bedsBroken
+                + "\n"
+                + ChatColor.GREEN + "Ranks, Boosters & MORE! " + ChatColor.RED + ChatColor.BOLD + "STORE.KARTERSANAMO.COM";
+        player.setPlayerListHeaderFooter(header, footer);
+    }
+
+    private List<String> buildLobbyLines(final IArena arena) {
+        final List<String> lines = new ArrayList<>();
+        final String date = new SimpleDateFormat("MM/dd/yy").format(new Date());
+        final String shortId = arena.getId().length() >= 4 ? arena.getId().substring(0, 4).toUpperCase(Locale.ROOT) : arena.getId().toUpperCase(Locale.ROOT);
+        lines.add(ChatColor.GRAY + date + " " + shortId);
+
+        lines.add(ChatColor.WHITE + "Map: " + ChatColor.GREEN + arena.getDisplayName());
+        final int current = arena.getPlayers().size();
+        final int max = arena.getMaxPlayers();
+        lines.add(ChatColor.GRAY + "Players: " + current + "/" + max);
+
+        final String status = arena.getGameState() == EGameState.STARTING
+                ? ChatColor.GRAY + "Starting..."
+                : ChatColor.GRAY + "Waiting...";
+        lines.add(status);
+
+        final String modeStr = modeName(arena.getTeamSize());
+        lines.add(ChatColor.WHITE + "Mode: " + ChatColor.GREEN + modeStr);
+
+        final String version = "v" + plugin.getDescription().getVersion();
+        lines.add(ChatColor.GRAY + "Version: " + version);
+
+        lines.add(ChatColor.GRAY + " ");
+        lines.add(ChatColor.RED + "play.kartersanamo.com");
+        return lines;
+    }
+
+    private static String modeName(final int teamSize) {
+        return switch (teamSize) {
+            case 1 -> "Solo";
+            case 2 -> "Doubles";
+            case 3 -> "3s";
+            case 4 -> "4s";
+            default -> teamSize + "s";
+        };
+    }
+
+    private List<String> buildGameLines(final IArena arena) {
+        final List<String> lines = new ArrayList<>();
+        final String date = new SimpleDateFormat("MM/dd/yy").format(new Date());
+        lines.add(ChatColor.GRAY + date);
+        lines.add(arena.getNextTierUpgradeMessage());
+        lines.add(ChatColor.GRAY + " ");
+        final List<ITeam> arenaTeams = arena.getTeams();
+        for (ETeamColor color : ETeamColor.values()) {
+            final Optional<ITeam> maybeTeam = arenaTeams.stream()
+                    .filter(team -> team.getColor() == color)
+                    .findFirst();
+            final String colorDisplayName = capitalize(color.name().toLowerCase(Locale.ROOT));
+            final String prefixLetter = color.name().substring(0, 1);
+            String status;
+            if (maybeTeam.isEmpty()) {
+                status = ChatColor.RED + "✖";
+            } else {
+                final ITeam team = maybeTeam.get();
+                if (!team.isBedDestroyed()) {
+                    status = ChatColor.GREEN + "✔";
+                } else {
+                    final long alive = team.getOnlineMembers().stream()
+                            .filter(p -> arena.contains(p) && !p.isDead())
+                            .count();
+                    status = alive > 0 ? ChatColor.YELLOW.toString() + alive : ChatColor.RED + "✖";
+                }
+            }
+            final String line = color.getChatColor() + prefixLetter + " "
+                    + color.getChatColor() + colorDisplayName + ChatColor.WHITE + ": " + status;
+            lines.add(line);
+        }
+        lines.add(ChatColor.GRAY + "  ");
+        lines.add(ChatColor.GOLD + "play.kartersanamo.com");
+        return lines;
+    }
+
+    private String capitalize(final String input) {
+        if (input == null || input.isEmpty()) return input;
         return Character.toUpperCase(input.charAt(0)) + input.substring(1);
     }
 }

--- a/src/main/java/com/kartersanamo/bedwars/sidebar/SidebarUpdateTask.java
+++ b/src/main/java/com/kartersanamo/bedwars/sidebar/SidebarUpdateTask.java
@@ -20,16 +20,17 @@ public final class SidebarUpdateTask extends BukkitRunnable {
     @Override
     public void run() {
         for (IArena arena : plugin.getArenaManager().getArenas()) {
-            sidebarService.updateForArena(arena);
             if (arena.getGameState() == com.kartersanamo.bedwars.api.arena.EGameState.IN_GAME
                     || arena.getGameState() == com.kartersanamo.bedwars.api.arena.EGameState.ENDING) {
                 if (arena instanceof com.kartersanamo.bedwars.arena.Arena a) {
+                    a.checkTierUpgrades();
                     for (org.bukkit.entity.Player player : arena.getPlayers()) {
                         a.ensureSword(player);
                         a.reapplyArmorIfNeeded(player);
                     }
                 }
             }
+            sidebarService.updateForArena(arena);
         }
     }
 }

--- a/src/main/java/com/kartersanamo/bedwars/upgrades/TeamUpgradeState.java
+++ b/src/main/java/com/kartersanamo/bedwars/upgrades/TeamUpgradeState.java
@@ -1,0 +1,105 @@
+package com.kartersanamo.bedwars.upgrades;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Per-team state for diamond upgrades and traps.
+ * Sharpness: single tier (bought once). Protection: 0–4. Haste: 0–2. Forge: 0–4. Heal Pool / Dragon Buff: boolean.
+ * Traps: queue of up to 3; cost 1 / 2 / 4 diamonds for 1st / 2nd / 3rd.
+ */
+public final class TeamUpgradeState {
+
+    private boolean sharpness;
+    private int protection; // 0-4
+    private int haste;       // 0-2
+    private int forge;       // 0=none, 1=iron, 2=golden, 3=emerald, 4=molten
+    private boolean healPool;
+    private boolean dragonBuff;
+    private final List<TrapType> trapQueue = new ArrayList<>(3);
+
+    public boolean hasSharpness() {
+        return sharpness;
+    }
+
+    public void setSharpness(final boolean sharpness) {
+        this.sharpness = sharpness;
+    }
+
+    public int getProtection() {
+        return protection;
+    }
+
+    public void setProtection(final int protection) {
+        this.protection = Math.max(0, Math.min(4, protection));
+    }
+
+    public int getHaste() {
+        return haste;
+    }
+
+    public void setHaste(final int haste) {
+        this.haste = Math.max(0, Math.min(2, haste));
+    }
+
+    public int getForge() {
+        return forge;
+    }
+
+    public void setForge(final int forge) {
+        this.forge = Math.max(0, Math.min(4, forge));
+    }
+
+    public boolean hasHealPool() {
+        return healPool;
+    }
+
+    public void setHealPool(final boolean healPool) {
+        this.healPool = healPool;
+    }
+
+    public boolean hasDragonBuff() {
+        return dragonBuff;
+    }
+
+    public void setDragonBuff(final boolean dragonBuff) {
+        this.dragonBuff = dragonBuff;
+    }
+
+    public List<TrapType> getTrapQueue() {
+        return Collections.unmodifiableList(new ArrayList<>(trapQueue));
+    }
+
+    public boolean addTrap(final TrapType trap) {
+        if (trapQueue.size() >= 3) {
+            return false;
+        }
+        trapQueue.add(trap);
+        return true;
+    }
+
+    /** Removes and returns the first queued trap, or null if none. */
+    public TrapType consumeNextTrap() {
+        return trapQueue.isEmpty() ? null : trapQueue.remove(0);
+    }
+
+    public int getTrapCostForNextPurchase() {
+        return switch (trapQueue.size()) {
+            case 0 -> 1;
+            case 1 -> 2;
+            case 2 -> 4;
+            default -> -1;
+        };
+    }
+
+    public void reset() {
+        sharpness = false;
+        protection = 0;
+        haste = 0;
+        forge = 0;
+        healPool = false;
+        dragonBuff = false;
+        trapQueue.clear();
+    }
+}

--- a/src/main/java/com/kartersanamo/bedwars/upgrades/TrapType.java
+++ b/src/main/java/com/kartersanamo/bedwars/upgrades/TrapType.java
@@ -1,0 +1,52 @@
+package com.kartersanamo.bedwars.upgrades;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+
+/**
+ * Trap types purchasable from the Upgrades & Traps GUI.
+ * Cost scales: 1st = 1 diamond, 2nd = 2, 3rd = 4. Max 3 queued.
+ */
+public enum TrapType {
+
+    ITS_A_TRAP("It's A Trap!", "Blindness and Slowness for 8 seconds.", Material.IRON_SHOVEL),
+    COUNTER_OFFENSIVE("Counter-Offensive Trap", "Gives you and nearby teammates Speed I and Jump Boost II for 10 seconds.", Material.FEATHER),
+    ALARM("Alarm Trap", "Reveals invisible players and plays a sound.", Material.REDSTONE_TORCH),
+    MINER_FATIGUE("Miner Fatigue Trap", "Inflict Mining Fatigue for 10 seconds.", Material.GOLDEN_PICKAXE);
+
+    private final String displayName;
+    private final String description;
+    private final Material icon;
+
+    TrapType(final String displayName, final String description, final Material icon) {
+        this.displayName = displayName;
+        this.description = description;
+        this.icon = icon;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Material getIcon() {
+        return icon;
+    }
+
+    public ItemStack toItemStack() {
+        final ItemStack stack = new ItemStack(icon);
+        final ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(displayName);
+            meta.setLore(List.of(description, "", "Cost: 1 Diamond (scales by queue)"));
+        }
+        stack.setItemMeta(meta);
+        return stack;
+    }
+}

--- a/src/main/java/com/kartersanamo/bedwars/upgrades/UpgradeManager.java
+++ b/src/main/java/com/kartersanamo/bedwars/upgrades/UpgradeManager.java
@@ -1,0 +1,307 @@
+package com.kartersanamo.bedwars.upgrades;
+
+import com.kartersanamo.bedwars.api.arena.IArena;
+import com.kartersanamo.bedwars.api.arena.team.ITeam;
+import com.kartersanamo.bedwars.arena.Arena;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Opens and fills the "Upgrades & Traps" GUI. Costs follow Hypixel: 1s/2s vs 3s/4s.
+ * Layout: slots 0-5 = 6 upgrades, 6-9 = 4 traps, 18-20 = 3 active trap slots (glass).
+ */
+public final class UpgradeManager {
+
+    private static final String TITLE = "Upgrades & Traps";
+    private static final int SIZE = 27;
+
+    private static final int SLOT_SHARPNESS = 0;
+    private static final int SLOT_PROTECTION = 1;
+    private static final int SLOT_HASTE = 2;
+    private static final int SLOT_FORGE = 3;
+    private static final int SLOT_HEAL_POOL = 4;
+    private static final int SLOT_DRAGON_BUFF = 5;
+    private static final int SLOT_TRAP_1 = 6;
+    private static final int SLOT_TRAP_2 = 7;
+    private static final int SLOT_TRAP_3 = 8;
+    private static final int SLOT_TRAP_4 = 9;
+    private static final int SLOT_ACTIVE_TRAP_1 = 18;
+    private static final int SLOT_ACTIVE_TRAP_2 = 19;
+    private static final int SLOT_ACTIVE_TRAP_3 = 20;
+
+    public void openGui(final Player player, final Arena arena, final ITeam team) {
+        final TeamUpgradeState state = arena.getTeamUpgradeState(team);
+        if (state == null) {
+            return;
+        }
+        final UpgradesGuiHolderImpl holder = new UpgradesGuiHolderImpl(arena, team);
+        final Inventory inv = Bukkit.createInventory(holder, SIZE, TITLE);
+        holder.setInventory(inv);
+
+        final boolean smallMode = arena.getTeamSize() <= 2;
+
+        // Upgrades (slots 0-5)
+        inv.setItem(SLOT_SHARPNESS, iconSharpness(state, smallMode));
+        inv.setItem(SLOT_PROTECTION, iconProtection(state, smallMode));
+        inv.setItem(SLOT_HASTE, iconHaste(state, smallMode));
+        inv.setItem(SLOT_FORGE, iconForge(state, smallMode));
+        inv.setItem(SLOT_HEAL_POOL, iconHealPool(state, smallMode));
+        inv.setItem(SLOT_DRAGON_BUFF, iconDragonBuff(state));
+
+        // Traps (slots 6-9) - 4 trap types
+        inv.setItem(SLOT_TRAP_1, iconTrap(TrapType.ITS_A_TRAP, state));
+        inv.setItem(SLOT_TRAP_2, iconTrap(TrapType.COUNTER_OFFENSIVE, state));
+        inv.setItem(SLOT_TRAP_3, iconTrap(TrapType.ALARM, state));
+        inv.setItem(SLOT_TRAP_4, iconTrap(TrapType.MINER_FATIGUE, state));
+
+        // Active traps (slots 18-20)
+        final List<TrapType> queue = state.getTrapQueue();
+        inv.setItem(SLOT_ACTIVE_TRAP_1, glassForTrap(queue.size() > 0 ? queue.get(0) : null, 1));
+        inv.setItem(SLOT_ACTIVE_TRAP_2, glassForTrap(queue.size() > 1 ? queue.get(1) : null, 2));
+        inv.setItem(SLOT_ACTIVE_TRAP_3, glassForTrap(queue.size() > 2 ? queue.get(2) : null, 3));
+
+        // Fill empty slots with barrier or gray glass so only our slots are clickable
+        final ItemStack filler = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        final ItemMeta fillerMeta = filler.getItemMeta();
+        if (fillerMeta != null) {
+            fillerMeta.setDisplayName(" ");
+        }
+        filler.setItemMeta(fillerMeta);
+        for (int i = 10; i <= 17; i++) {
+            inv.setItem(i, filler);
+        }
+        for (int i = 21; i < SIZE; i++) {
+            inv.setItem(i, filler);
+        }
+
+        player.openInventory(inv);
+    }
+
+    private static ItemStack iconSharpness(final TeamUpgradeState state, final boolean smallMode) {
+        final ItemStack stack = new ItemStack(Material.IRON_SWORD);
+        final ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RED + "Sharpened Swords");
+            final int cost = smallMode ? 4 : 8;
+            final List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.WHITE + "Your team permanently gains Sharpness I on swords!");
+            lore.add("");
+            lore.add(ChatColor.WHITE + "Tier 1: Sharpness I - " + ChatColor.AQUA + cost + " Diamonds");
+            if (state.hasSharpness()) {
+                lore.add(ChatColor.GREEN + "Already purchased!");
+            } else {
+                lore.add(ChatColor.AQUA + "Cost: " + cost + " Diamonds");
+            }
+            meta.setLore(lore);
+        }
+        stack.setItemMeta(meta);
+        return stack;
+    }
+
+    private static ItemStack iconProtection(final TeamUpgradeState state, final boolean smallMode) {
+        final ItemStack stack = new ItemStack(Material.IRON_CHESTPLATE);
+        final ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RED + "Reinforced Armor");
+            final List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.WHITE + "Your team permanently gains Protection on armor!");
+            lore.add("");
+            final int[] costs = smallMode ? new int[]{2, 4, 8, 16} : new int[]{5, 10, 20, 30};
+            for (int i = 0; i < 4; i++) {
+                final int tier = i + 1;
+                lore.add(ChatColor.WHITE + "Tier " + tier + ": Protection " + tier + " - " + ChatColor.AQUA + costs[i] + " Diamonds");
+            }
+            if (state.getProtection() >= 4) {
+                lore.add(ChatColor.GREEN + "Maxed!");
+            } else {
+                final int nextCost = costs[state.getProtection()];
+                lore.add(ChatColor.AQUA + "Next: " + nextCost + " Diamonds");
+            }
+            meta.setLore(lore);
+        }
+        stack.setItemMeta(meta);
+        return stack;
+    }
+
+    private static ItemStack iconHaste(final TeamUpgradeState state, final boolean smallMode) {
+        final ItemStack stack = new ItemStack(Material.GOLDEN_PICKAXE);
+        final ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RED + "Maniac Miner");
+            final List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.WHITE + "Your team permanently gains Haste!");
+            lore.add("");
+            final int c1 = smallMode ? 2 : 4;
+            final int c2 = smallMode ? 4 : 6;
+            lore.add(ChatColor.WHITE + "Tier 1: Haste I - " + ChatColor.AQUA + c1 + " Diamonds");
+            lore.add(ChatColor.WHITE + "Tier 2: Haste II - " + ChatColor.AQUA + c2 + " Diamonds");
+            if (state.getHaste() >= 2) {
+                lore.add(ChatColor.GREEN + "Maxed!");
+            } else {
+                final int nextCost = state.getHaste() == 0 ? c1 : c2;
+                lore.add(ChatColor.AQUA + "Next: " + nextCost + " Diamonds");
+            }
+            meta.setLore(lore);
+        }
+        stack.setItemMeta(meta);
+        return stack;
+    }
+
+    private static ItemStack iconForge(final TeamUpgradeState state, final boolean smallMode) {
+        final ItemStack stack = new ItemStack(Material.FURNACE);
+        final ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RED + "Forge");
+            final List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.WHITE + "Upgrade your generator speed!");
+            lore.add("");
+            final int[] costs = smallMode ? new int[]{2, 4, 6, 8} : new int[]{4, 8, 12, 16};
+            lore.add(ChatColor.WHITE + "Iron Forge: +50% - " + ChatColor.AQUA + costs[0] + " Diamonds");
+            lore.add(ChatColor.WHITE + "Golden Forge: +100% - " + ChatColor.AQUA + costs[1] + " Diamonds");
+            lore.add(ChatColor.WHITE + "Emerald Forge: +emeralds - " + ChatColor.AQUA + costs[2] + " Diamonds");
+            lore.add(ChatColor.WHITE + "Molten Forge: +200% - " + ChatColor.AQUA + costs[3] + " Diamonds");
+            if (state.getForge() >= 4) {
+                lore.add(ChatColor.GREEN + "Maxed!");
+            } else {
+                lore.add(ChatColor.AQUA + "Next: " + costs[state.getForge()] + " Diamonds");
+            }
+            meta.setLore(lore);
+        }
+        stack.setItemMeta(meta);
+        return stack;
+    }
+
+    private static ItemStack iconHealPool(final TeamUpgradeState state, final boolean smallMode) {
+        final ItemStack stack = new ItemStack(Material.BEACON);
+        final ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RED + "Heal Pool");
+            final int cost = smallMode ? 1 : 3;
+            final List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.WHITE + "Creates a regeneration field at your base!");
+            lore.add(ChatColor.WHITE + "You and teammates gain Regeneration I at base.");
+            lore.add("");
+            lore.add(ChatColor.WHITE + "Cost: " + ChatColor.AQUA + cost + " Diamonds");
+            if (state.hasHealPool()) {
+                lore.add(ChatColor.GREEN + "Already purchased!");
+            }
+            meta.setLore(lore);
+        }
+        stack.setItemMeta(meta);
+        return stack;
+    }
+
+    private static ItemStack iconDragonBuff(final TeamUpgradeState state) {
+        final ItemStack stack = new ItemStack(Material.ENCHANTING_TABLE);
+        final ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RED + "Dragon Buff");
+            final List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.WHITE + "Spawns an extra dragon for your team in sudden death.");
+            lore.add("");
+            lore.add(ChatColor.WHITE + "Cost: " + ChatColor.AQUA + "5 Diamonds");
+            if (state.hasDragonBuff()) {
+                lore.add(ChatColor.GREEN + "Already purchased!");
+            }
+            meta.setLore(lore);
+        }
+        stack.setItemMeta(meta);
+        return stack;
+    }
+
+    private static ItemStack iconTrap(final TrapType trap, final TeamUpgradeState state) {
+        final ItemStack stack = new ItemStack(trap.getIcon());
+        final ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RED + trap.getDisplayName());
+            final List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.WHITE + trap.getDescription());
+            lore.add("");
+            lore.add(ChatColor.WHITE + "Purchasing a trap will queue it. Cost scales by queue size.");
+            final int cost = state.getTrapCostForNextPurchase();
+            if (cost < 0) {
+                lore.add(ChatColor.RED + "Maximum traps (3) reached!");
+            } else {
+                lore.add(ChatColor.AQUA + "Next trap: " + cost + " Diamond(s)");
+            }
+            meta.setLore(lore);
+        }
+        stack.setItemMeta(meta);
+        return stack;
+    }
+
+    private static ItemStack glassForTrap(final TrapType trap, final int slotNumber) {
+        final ItemStack stack = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        final ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            if (trap != null) {
+                meta.setDisplayName(ChatColor.GRAY + "Trap #" + slotNumber + ": " + trap.getDisplayName());
+                meta.setLore(List.of(
+                        ChatColor.WHITE + "The " + ordinal(slotNumber) + " enemy to walk into your base will trigger this trap!",
+                        "",
+                        ChatColor.WHITE + "Purchasing a trap will queue it here. Cost scales by queue size."
+                ));
+            } else {
+                meta.setDisplayName(ChatColor.RED + "Trap #" + slotNumber + ": No Trap!");
+                meta.setLore(List.of(
+                        ChatColor.WHITE + "The " + ordinal(slotNumber) + " enemy to walk into your base will trigger this trap!",
+                        "",
+                        ChatColor.WHITE + "Purchasing a trap will queue it here. Cost scales by queue size.",
+                        ChatColor.AQUA + "Next trap: 1 Diamond"
+                ));
+            }
+        }
+        stack.setItemMeta(meta);
+        return stack;
+    }
+
+    private static String ordinal(final int n) {
+        return switch (n) {
+            case 1 -> "first";
+            case 2 -> "second";
+            case 3 -> "third";
+            default -> n + "th";
+        };
+    }
+
+    /** Cost for Sharpness: 4 (1s/2s) or 8 (3s/4s). */
+    public static int getSharpnessCost(final IArena arena) {
+        return arena.getTeamSize() <= 2 ? 4 : 8;
+    }
+
+    /** Cost for next Protection tier (0->1, 1->2, 2->3, 3->4). */
+    public static int getProtectionCost(final int currentTier, final IArena arena) {
+        final int[] costs = arena.getTeamSize() <= 2 ? new int[]{2, 4, 8, 16} : new int[]{5, 10, 20, 30};
+        return currentTier < 4 ? costs[currentTier] : -1;
+    }
+
+    /** Cost for next Haste tier (0->1, 1->2). */
+    public static int getHasteCost(final int currentTier, final IArena arena) {
+        if (currentTier >= 2) return -1;
+        return arena.getTeamSize() <= 2 ? (currentTier == 0 ? 2 : 4) : (currentTier == 0 ? 4 : 6);
+    }
+
+    /** Cost for next Forge tier (0->1, 1->2, 2->3, 3->4). */
+    public static int getForgeCost(final int currentTier, final IArena arena) {
+        final int[] costs = arena.getTeamSize() <= 2 ? new int[]{2, 4, 6, 8} : new int[]{4, 8, 12, 16};
+        return currentTier < 4 ? costs[currentTier] : -1;
+    }
+
+    /** Heal Pool: 1 (1s/2s) or 3 (3s/4s). */
+    public static int getHealPoolCost(final IArena arena) {
+        return arena.getTeamSize() <= 2 ? 1 : 3;
+    }
+
+    /** Dragon Buff: 5. */
+    public static int getDragonBuffCost() {
+        return 5;
+    }
+}

--- a/src/main/java/com/kartersanamo/bedwars/upgrades/UpgradesGuiHolder.java
+++ b/src/main/java/com/kartersanamo/bedwars/upgrades/UpgradesGuiHolder.java
@@ -1,0 +1,15 @@
+package com.kartersanamo.bedwars.upgrades;
+
+import com.kartersanamo.bedwars.api.arena.team.ITeam;
+import com.kartersanamo.bedwars.arena.Arena;
+import org.bukkit.inventory.InventoryHolder;
+
+/**
+ * Holder for the "Upgrades & Traps" GUI. Tracks arena and team so purchases apply to the correct team.
+ */
+public interface UpgradesGuiHolder extends InventoryHolder {
+
+    Arena getArena();
+
+    ITeam getTeam();
+}

--- a/src/main/java/com/kartersanamo/bedwars/upgrades/UpgradesGuiHolderImpl.java
+++ b/src/main/java/com/kartersanamo/bedwars/upgrades/UpgradesGuiHolderImpl.java
@@ -1,0 +1,37 @@
+package com.kartersanamo.bedwars.upgrades;
+
+import com.kartersanamo.bedwars.api.arena.team.ITeam;
+import com.kartersanamo.bedwars.arena.Arena;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+public final class UpgradesGuiHolderImpl implements UpgradesGuiHolder {
+
+    private final Arena arena;
+    private final ITeam team;
+    private Inventory inventory;
+
+    public UpgradesGuiHolderImpl(final Arena arena, final ITeam team) {
+        this.arena = arena;
+        this.team = team;
+    }
+
+    @Override
+    public Arena getArena() {
+        return arena;
+    }
+
+    @Override
+    public ITeam getTeam() {
+        return team;
+    }
+
+    public void setInventory(final Inventory inventory) {
+        this.inventory = inventory;
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+}

--- a/src/main/java/com/kartersanamo/bedwars/upgrades/UpgradesInventoryListener.java
+++ b/src/main/java/com/kartersanamo/bedwars/upgrades/UpgradesInventoryListener.java
@@ -1,0 +1,235 @@
+package com.kartersanamo.bedwars.upgrades;
+
+import com.kartersanamo.bedwars.api.arena.team.ITeam;
+import com.kartersanamo.bedwars.arena.Arena;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Handles clicks in the "Upgrades & Traps" GUI: purchase upgrades/traps with diamonds and refresh display.
+ */
+public final class UpgradesInventoryListener implements Listener {
+
+    private final UpgradeManager upgradeManager;
+
+    public UpgradesInventoryListener(final UpgradeManager upgradeManager) {
+        this.upgradeManager = upgradeManager;
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onInventoryClick(final InventoryClickEvent event) {
+        if (!(event.getInventory().getHolder() instanceof UpgradesGuiHolder holder)) {
+            return;
+        }
+        event.setCancelled(true);
+
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+
+        final Arena arena = holder.getArena();
+        final ITeam team = holder.getTeam();
+        final TeamUpgradeState state = arena.getTeamUpgradeState(team);
+        if (state == null) {
+            return;
+        }
+
+        final int slot = event.getRawSlot();
+        if (slot < 0 || slot >= 27) {
+            return;
+        }
+
+        // Active trap slots (18-20) are display-only
+        if (slot >= 18 && slot <= 20) {
+            return;
+        }
+
+        // Filler slots (10-17, 21-26) - no action
+        if ((slot >= 10 && slot <= 17) || slot >= 21) {
+            return;
+        }
+
+        final int diamonds = countDiamonds(player);
+
+        switch (slot) { // slot 0-5 upgrades, 6-9 traps
+            case 0 -> tryBuySharpness(player, state, diamonds, arena, team);
+            case 1 -> tryBuyProtection(player, state, diamonds, arena, team);
+            case 2 -> tryBuyHaste(player, state, diamonds, arena, team);
+            case 3 -> tryBuyForge(player, state, diamonds, arena, team);
+            case 4 -> tryBuyHealPool(player, state, diamonds, arena, team);
+            case 5 -> tryBuyDragonBuff(player, state, diamonds, arena, team);
+            case 6 -> tryBuyTrap(player, state, diamonds, TrapType.ITS_A_TRAP, arena, team);
+            case 7 -> tryBuyTrap(player, state, diamonds, TrapType.COUNTER_OFFENSIVE, arena, team);
+            case 8 -> tryBuyTrap(player, state, diamonds, TrapType.ALARM, arena, team);
+            case 9 -> tryBuyTrap(player, state, diamonds, TrapType.MINER_FATIGUE, arena, team);
+            default -> { }
+        }
+    }
+
+    private static int countDiamonds(final Player player) {
+        int count = 0;
+        for (ItemStack item : player.getInventory().getContents()) {
+            if (item != null && item.getType() == Material.DIAMOND) {
+                count += item.getAmount();
+            }
+        }
+        return count;
+    }
+
+    private static boolean takeDiamonds(final Player player, final int amount) {
+        if (amount <= 0) return true;
+        int remaining = amount;
+        for (int i = 0; i < player.getInventory().getSize() && remaining > 0; i++) {
+            final ItemStack stack = player.getInventory().getItem(i);
+            if (stack != null && stack.getType() == Material.DIAMOND) {
+                final int take = Math.min(remaining, stack.getAmount());
+                remaining -= take;
+                if (stack.getAmount() <= take) {
+                    player.getInventory().setItem(i, null);
+                } else {
+                    stack.setAmount(stack.getAmount() - take);
+                }
+            }
+        }
+        return remaining <= 0;
+    }
+
+    private void tryBuySharpness(final Player player, final TeamUpgradeState state, final int diamonds, final Arena arena, final ITeam team) {
+        if (state.hasSharpness()) {
+            player.sendMessage(ChatColor.RED + "You already have Sharpened Swords!");
+            return;
+        }
+        final int cost = UpgradeManager.getSharpnessCost(arena);
+        if (diamonds < cost) {
+            player.sendMessage(ChatColor.RED + "You don't have enough Diamonds!");
+            return;
+        }
+        if (!takeDiamonds(player, cost)) {
+            return;
+        }
+        state.setSharpness(true);
+        player.sendMessage(ChatColor.GREEN + "Purchased Sharpened Swords!");
+        refreshGui(player, arena, team);
+    }
+
+    private void tryBuyProtection(final Player player, final TeamUpgradeState state, final int diamonds, final Arena arena, final ITeam team) {
+        final int current = state.getProtection();
+        if (current >= 4) {
+            player.sendMessage(ChatColor.RED + "Protection is already maxed!");
+            return;
+        }
+        final int cost = UpgradeManager.getProtectionCost(current, arena);
+        if (diamonds < cost) {
+            player.sendMessage(ChatColor.RED + "You don't have enough Diamonds!");
+            return;
+        }
+        if (!takeDiamonds(player, cost)) {
+            return;
+        }
+        state.setProtection(current + 1);
+        player.sendMessage(ChatColor.GREEN + "Purchased Protection " + (current + 1) + "!");
+        refreshGui(player, arena, team);
+    }
+
+    private void tryBuyHaste(final Player player, final TeamUpgradeState state, final int diamonds, final Arena arena, final ITeam team) {
+        final int current = state.getHaste();
+        if (current >= 2) {
+            player.sendMessage(ChatColor.RED + "Maniac Miner is already maxed!");
+            return;
+        }
+        final int cost = UpgradeManager.getHasteCost(current, arena);
+        if (diamonds < cost) {
+            player.sendMessage(ChatColor.RED + "You don't have enough Diamonds!");
+            return;
+        }
+        if (!takeDiamonds(player, cost)) {
+            return;
+        }
+        state.setHaste(current + 1);
+        player.sendMessage(ChatColor.GREEN + "Purchased Haste " + (current + 1) + "!");
+        refreshGui(player, arena, team);
+    }
+
+    private void tryBuyForge(final Player player, final TeamUpgradeState state, final int diamonds, final Arena arena, final ITeam team) {
+        final int current = state.getForge();
+        if (current >= 4) {
+            player.sendMessage(ChatColor.RED + "Forge is already maxed!");
+            return;
+        }
+        final int cost = UpgradeManager.getForgeCost(current, arena);
+        if (diamonds < cost) {
+            player.sendMessage(ChatColor.RED + "You don't have enough Diamonds!");
+            return;
+        }
+        if (!takeDiamonds(player, cost)) {
+            return;
+        }
+        state.setForge(current + 1);
+        player.sendMessage(ChatColor.GREEN + "Purchased Forge upgrade!");
+        refreshGui(player, arena, team);
+    }
+
+    private void tryBuyHealPool(final Player player, final TeamUpgradeState state, final int diamonds, final Arena arena, final ITeam team) {
+        if (state.hasHealPool()) {
+            player.sendMessage(ChatColor.RED + "You already have Heal Pool!");
+            return;
+        }
+        final int cost = UpgradeManager.getHealPoolCost(arena);
+        if (diamonds < cost) {
+            player.sendMessage(ChatColor.RED + "You don't have enough Diamonds!");
+            return;
+        }
+        if (!takeDiamonds(player, cost)) {
+            return;
+        }
+        state.setHealPool(true);
+        player.sendMessage(ChatColor.GREEN + "Purchased Heal Pool!");
+        refreshGui(player, arena, team);
+    }
+
+    private void tryBuyDragonBuff(final Player player, final TeamUpgradeState state, final int diamonds, final Arena arena, final ITeam team) {
+        if (state.hasDragonBuff()) {
+            player.sendMessage(ChatColor.RED + "You already have Dragon Buff!");
+            return;
+        }
+        final int cost = UpgradeManager.getDragonBuffCost();
+        if (diamonds < cost) {
+            player.sendMessage(ChatColor.RED + "You don't have enough Diamonds!");
+            return;
+        }
+        if (!takeDiamonds(player, cost)) {
+            return;
+        }
+        state.setDragonBuff(true);
+        player.sendMessage(ChatColor.GREEN + "Purchased Dragon Buff!");
+        refreshGui(player, arena, team);
+    }
+
+    private void tryBuyTrap(final Player player, final TeamUpgradeState state, final int diamonds, final TrapType trap, final Arena arena, final ITeam team) {
+        final int cost = state.getTrapCostForNextPurchase();
+        if (cost < 0) {
+            player.sendMessage(ChatColor.RED + "Maximum traps (3) reached!");
+            return;
+        }
+        if (diamonds < cost) {
+            player.sendMessage(ChatColor.RED + "You don't have enough Diamonds!");
+            return;
+        }
+        if (!takeDiamonds(player, cost)) {
+            return;
+        }
+        state.addTrap(trap);
+        player.sendMessage(ChatColor.GREEN + "Purchased " + trap.getDisplayName() + "!");
+        refreshGui(player, arena, team);
+    }
+
+    private void refreshGui(final Player player, final Arena arena, final ITeam team) {
+        if (team == null) return;
+        upgradeManager.openGui(player, arena, team);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,25 +22,27 @@ arena:
 gameplay:
   respawn-delay-seconds: 5
   void-y: 0
+  # Max dropped items per generator on the ground; when reached, generator stops until items are picked up.
+  # Spawn island: 48 iron, 12 gold per generator. Mid: 4 diamonds, 2 emeralds per generator.
   generator-caps:
     solo:
       iron: 48
-      gold: 8
+      gold: 12
       diamond: 4
       emerald: 2
     doubles:
       iron: 48
-      gold: 8
+      gold: 12
       diamond: 4
       emerald: 2
     threes:
       iron: 48
-      gold: 8
+      gold: 12
       diamond: 4
       emerald: 2
     fours:
       iron: 48
-      gold: 8
+      gold: 12
       diamond: 4
       emerald: 2
 


### PR DESCRIPTION
- Added upgrade NPCs to the arena configuration for both teams.
- Introduced a new UpgradeManager to handle upgrade logic.
- Updated ArenaManager to spawn upgrade NPCs and manage their interactions.
- Enhanced game mechanics to include tier upgrades for diamond and emerald generators.
- Implemented methods in IArena for tracking and broadcasting game-over summaries and player kills.
- Improved block placement restrictions near generators and NPCs for better gameplay balance.